### PR TITLE
feat(board-comment): 댓글 등록 기능 구현

### DIFF
--- a/domain/mathrank-board-comment/build.gradle
+++ b/domain/mathrank-board-comment/build.gradle
@@ -1,0 +1,10 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.h2database:h2'
+
+    implementation project(':common:mathrank-snowflake')
+}

--- a/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/dto/CommentDeleteCommand.java
+++ b/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/dto/CommentDeleteCommand.java
@@ -1,0 +1,11 @@
+package kr.co.mathrank.domain.board.comment.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CommentDeleteCommand(
+	@NotNull
+	Long commentId,
+	@NotNull
+	Long requestMemberId
+) {
+}

--- a/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/dto/CommentRegisterCommand.java
+++ b/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/dto/CommentRegisterCommand.java
@@ -1,0 +1,17 @@
+package kr.co.mathrank.domain.board.comment.dto;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CommentRegisterCommand(
+	@NotNull
+	Long postId,
+	@NotNull
+	Long userId,
+	@NotNull
+	String content,
+	@NotNull
+	List<String> images
+) {
+}

--- a/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/dto/CommentResult.java
+++ b/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/dto/CommentResult.java
@@ -1,0 +1,27 @@
+package kr.co.mathrank.domain.board.comment.dto;
+
+import java.util.List;
+
+import kr.co.mathrank.domain.board.comment.entity.Comment;
+
+public record CommentResult(
+	Long postId,
+	Long commentId,
+	String content,
+	List<String> images,
+	Long userId,
+	String createdAt,
+	String updatedAt
+) {
+	public static CommentResult from(final Comment comment) {
+		return new CommentResult(
+			comment.getPostId(),
+			comment.getId(),
+			comment.getContent(),
+			comment.getImageSources(),
+			comment.getUserId(),
+			comment.getCreatedAt().toString(),
+			comment.getUpdatedAt().toString()
+		);
+	}
+}

--- a/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/dto/CommentResults.java
+++ b/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/dto/CommentResults.java
@@ -1,0 +1,8 @@
+package kr.co.mathrank.domain.board.comment.dto;
+
+import java.util.List;
+
+public record CommentResults(
+	List<CommentResult> comments
+) {
+}

--- a/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/dto/CommentUpdateCommand.java
+++ b/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/dto/CommentUpdateCommand.java
@@ -1,0 +1,17 @@
+package kr.co.mathrank.domain.board.comment.dto;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CommentUpdateCommand(
+	@NotNull
+	Long commentId,
+	@NotNull
+	Long userId,
+	@NotNull
+	String content,
+	@NotNull
+	List<String> images
+) {
+}

--- a/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/entity/Comment.java
+++ b/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/entity/Comment.java
@@ -1,0 +1,96 @@
+package kr.co.mathrank.domain.board.comment.entity;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.domain.Persistable;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment implements Persistable<Long> {
+	@Id
+	private Long id;
+
+	private Long postId;
+
+	@Setter
+	private String content;
+
+	private Long userId;
+
+	private LocalDateTime createdAt;
+
+	private LocalDateTime updatedAt;
+
+	@OneToMany(mappedBy = "comment", cascade = CascadeType.PERSIST, orphanRemoval = true)
+	@Getter(AccessLevel.NONE)
+	private final List<Image> images = new ArrayList<>();
+
+	public static Comment of(final Long id, final Long postId, final String content, final Long userId, final List<String> imageSources) {
+		final Comment comment = new Comment();
+		comment.id = id;
+		comment.postId = postId;
+		comment.content = content;
+		comment.userId = userId;
+		comment.setImages(imageSources);
+
+		return comment;
+	}
+
+	public List<String> getImageSources() {
+		return images.stream()
+			.map(Image::getImageSrc)
+			.toList();
+	}
+
+	public void updateImages(final List<String> imageSources) {
+		this.images.clear();
+		this.setImages(imageSources);
+	}
+
+	private void setImages(final List<String> images) {
+		this.images.addAll(images.stream()
+			.map(imageSrc -> Image.of(imageSrc, this))
+			.toList());
+	}
+
+	@Override
+	public boolean isNew() {
+		log.debug("isNew() called for Comment with id: {}, result: {}", id, createdAt == null);
+		return createdAt == null;
+	}
+
+	@PrePersist
+	private void prePersist() {
+		final LocalDateTime now = LocalDateTime.now();
+
+		if (createdAt == null) {
+			createdAt = now;
+		}
+		if (updatedAt == null) {
+			updatedAt = now;
+		}
+		log.debug("PrePersist called for Comment with id: {}, createdAt: {}, updatedAt: {}", id, createdAt, updatedAt);
+	}
+
+	@PreUpdate
+	private void preUpdate() {
+		updatedAt = LocalDateTime.now();
+		log.debug("PreUpdate called for Comment with id: {}, updatedAt: {}", id, updatedAt);
+	}
+}

--- a/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/entity/Image.java
+++ b/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/entity/Image.java
@@ -1,0 +1,33 @@
+package kr.co.mathrank.domain.board.comment.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+class Image {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String imageSrc;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Comment comment;
+
+	public static Image of(final String imageSrc, final Comment comment) {
+		final Image image = new Image();
+		image.imageSrc = imageSrc;
+		image.comment = comment;
+
+		return image;
+	}
+}

--- a/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/repository/CommentRepository.java
+++ b/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/repository/CommentRepository.java
@@ -1,0 +1,8 @@
+package kr.co.mathrank.domain.board.comment.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.co.mathrank.domain.board.comment.entity.Comment;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/repository/CommentRepository.java
+++ b/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/repository/CommentRepository.java
@@ -1,5 +1,6 @@
 package kr.co.mathrank.domain.board.comment.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,7 @@ import kr.co.mathrank.domain.board.comment.entity.Comment;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 	@Query("SELECT c FROM Comment c LEFT JOIN FETCH c.images WHERE c.id = :commentId")
 	Optional<Comment> findWithImages(@Param("commentId") Long commentId);
+
+	@Query("SELECT c FROM Comment c LEFT JOIN FETCH c.images WHERE c.postId = :postId ORDER BY c.createdAt ASC")
+	List<Comment> queryAllByPostIdSortedByCreatedAt(Long postId);
 }

--- a/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/repository/CommentRepository.java
+++ b/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/repository/CommentRepository.java
@@ -1,8 +1,14 @@
 package kr.co.mathrank.domain.board.comment.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import kr.co.mathrank.domain.board.comment.entity.Comment;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+	@Query("SELECT c FROM Comment c LEFT JOIN FETCH c.images WHERE c.id = :commentId")
+	Optional<Comment> findWithImages(@Param("commentId") Long commentId);
 }

--- a/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/service/CommentQueryService.java
+++ b/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/service/CommentQueryService.java
@@ -1,0 +1,24 @@
+package kr.co.mathrank.domain.board.comment.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.domain.board.comment.dto.CommentResult;
+import kr.co.mathrank.domain.board.comment.dto.CommentResults;
+import kr.co.mathrank.domain.board.comment.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Validated
+@RequiredArgsConstructor
+public class CommentQueryService {
+	private final CommentRepository commentRepository;
+
+	public CommentResults queryComments(@NotNull final Long postId) {
+		return new CommentResults(commentRepository.queryAllByPostIdSortedByCreatedAt(postId)
+			.stream()
+			.map(CommentResult::from)
+			.toList());
+	}
+}

--- a/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/service/CommentService.java
+++ b/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/service/CommentService.java
@@ -2,6 +2,7 @@ package kr.co.mathrank.domain.board.comment.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -14,6 +15,7 @@ import kr.co.mathrank.domain.board.comment.repository.CommentRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
+@Validated
 @RequiredArgsConstructor
 public class CommentService {
 	private final CommentRepository commentRepository;

--- a/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/service/CommentService.java
+++ b/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/service/CommentService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import kr.co.mathrank.common.snowflake.Snowflake;
+import kr.co.mathrank.domain.board.comment.dto.CommentDeleteCommand;
 import kr.co.mathrank.domain.board.comment.dto.CommentRegisterCommand;
 import kr.co.mathrank.domain.board.comment.dto.CommentUpdateCommand;
 import kr.co.mathrank.domain.board.comment.entity.Comment;
@@ -33,6 +34,15 @@ public class CommentService {
 
 		comment.setContent(command.content());
 		comment.updateImages(command.images());
+	}
+
+	@Transactional
+	public void delete(@NotNull @Valid final CommentDeleteCommand command) {
+		final Comment comment = commentRepository.findWithImages(command.commentId())
+			.orElseThrow(() -> new IllegalArgumentException("Comment not found with id: " + command.commentId()));
+		isOwner(comment, command.requestMemberId());
+
+		commentRepository.delete(comment);
 	}
 
 	private void isOwner(final Comment comment, final Long userId) {

--- a/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/service/CommentService.java
+++ b/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/service/CommentService.java
@@ -1,0 +1,25 @@
+package kr.co.mathrank.domain.board.comment.service;
+
+import org.springframework.stereotype.Service;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.common.snowflake.Snowflake;
+import kr.co.mathrank.domain.board.comment.dto.CommentRegisterCommand;
+import kr.co.mathrank.domain.board.comment.entity.Comment;
+import kr.co.mathrank.domain.board.comment.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+	private final CommentRepository commentRepository;
+	private final Snowflake snowflake;
+
+	public Long save(@NotNull @Valid final CommentRegisterCommand command) {
+		final Long id = snowflake.nextId();
+		final Comment comment = Comment.of(id, command.postId(), command.content(), command.userId(), command.images());
+		commentRepository.save(comment);
+		return comment.getId();
+	}
+}

--- a/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/service/CommentService.java
+++ b/domain/mathrank-board-comment/src/main/java/kr/co/mathrank/domain/board/comment/service/CommentService.java
@@ -1,11 +1,13 @@
 package kr.co.mathrank.domain.board.comment.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import kr.co.mathrank.common.snowflake.Snowflake;
 import kr.co.mathrank.domain.board.comment.dto.CommentRegisterCommand;
+import kr.co.mathrank.domain.board.comment.dto.CommentUpdateCommand;
 import kr.co.mathrank.domain.board.comment.entity.Comment;
 import kr.co.mathrank.domain.board.comment.repository.CommentRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,5 +23,21 @@ public class CommentService {
 		final Comment comment = Comment.of(id, command.postId(), command.content(), command.userId(), command.images());
 		commentRepository.save(comment);
 		return comment.getId();
+	}
+
+	@Transactional
+	public void update(@NotNull @Valid final CommentUpdateCommand command) {
+		final Comment comment = commentRepository.findWithImages(command.commentId())
+			.orElseThrow(() -> new IllegalArgumentException("Comment not found with id: " + command.commentId()));
+		isOwner(comment, command.userId());
+
+		comment.setContent(command.content());
+		comment.updateImages(command.images());
+	}
+
+	private void isOwner(final Comment comment, final Long userId) {
+		if (!comment.getUserId().equals(userId)) {
+			throw new IllegalArgumentException("You do not have permission to perform this action.");
+		}
 	}
 }

--- a/domain/mathrank-board-comment/src/test/java/kr/co/mathrank/BoardCommentDomainApplication.java
+++ b/domain/mathrank-board-comment/src/test/java/kr/co/mathrank/BoardCommentDomainApplication.java
@@ -1,0 +1,7 @@
+package kr.co.mathrank;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BoardCommentDomainApplication {
+}

--- a/domain/mathrank-board-comment/src/test/java/kr/co/mathrank/domain/board/comment/service/CommentQueryServiceTest.java
+++ b/domain/mathrank-board-comment/src/test/java/kr/co/mathrank/domain/board/comment/service/CommentQueryServiceTest.java
@@ -1,0 +1,37 @@
+package kr.co.mathrank.domain.board.comment.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.co.mathrank.domain.board.comment.dto.CommentRegisterCommand;
+import kr.co.mathrank.domain.board.comment.dto.CommentResults;
+
+@SpringBootTest
+class CommentQueryServiceTest {
+	@Autowired
+	private CommentQueryService commentQueryService;
+	@Autowired
+	private CommentService commentService;
+
+	@Test
+	@Transactional
+	void 댓글_조회_생성_오름차순() {
+		// Given
+		final Long postId = 1L;
+		commentService.save(new CommentRegisterCommand(postId, 2L, "테스트 댓글1", List.of("image1.jpg", "image2.jpg")));
+		commentService.save(new CommentRegisterCommand(postId, 2L, "테스트 댓글2", List.of("image1.jpg", "image2.jpg")));
+		commentService.save(new CommentRegisterCommand(postId, 2L, "테스트 댓글3", List.of("image1.jpg", "image2.jpg")));
+
+		// When
+		final CommentResults results = commentQueryService.queryComments(postId);
+
+		// Then
+		assertEquals("테스트 댓글1", results.comments().get(0).content());
+	}
+}

--- a/domain/mathrank-board-comment/src/test/java/kr/co/mathrank/domain/board/comment/service/CommentServiceTest.java
+++ b/domain/mathrank-board-comment/src/test/java/kr/co/mathrank/domain/board/comment/service/CommentServiceTest.java
@@ -1,0 +1,101 @@
+package kr.co.mathrank.domain.board.comment.service;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import kr.co.mathrank.domain.board.comment.dto.CommentRegisterCommand;
+import kr.co.mathrank.domain.board.comment.entity.Comment;
+import kr.co.mathrank.domain.board.comment.repository.CommentRepository;
+
+@SpringBootTest
+class CommentServiceTest {
+	@Autowired
+	private CommentService commentService;
+	@Autowired
+	private CommentRepository commentRepository;
+
+	@PersistenceContext
+	private EntityManager em;
+
+	@Test
+	@Transactional
+	void 댓글_등록_정상동작_확인() {
+		final Long id = commentService.save(new CommentRegisterCommand(1L, 2L, "테스트 댓글", List.of("image1.jpg", "image2.jpg")));
+
+		em.flush();
+		em.clear();
+
+		final Comment comment = commentRepository.findById(id)
+			.orElseThrow();
+
+		Assertions.assertEquals(1L, comment.getPostId());
+		Assertions.assertEquals(2L, comment.getUserId());
+		Assertions.assertEquals("테스트 댓글", comment.getContent());
+		Assertions.assertEquals(2, comment.getImageSources().size());
+
+		System.out.println("Image Sources: " + comment.getImageSources());
+		Assertions.assertTrue(comment.getImageSources().contains("image1.jpg"));
+		Assertions.assertTrue(comment.getImageSources().contains("image2.jpg"));
+	}
+
+	@Test
+	@Transactional
+	void 생성_날짜_및_수정_날짜_일치_확인() {
+		final Long id = commentService.save(new CommentRegisterCommand(1L, 2L, "테스트 댓글", List.of("image1.jpg", "image2.jpg")));
+		em.flush();
+		em.clear();
+
+		final Comment comment = commentRepository.findById(id)
+			.orElseThrow();
+		Assertions.assertNotNull(comment.getCreatedAt(), "생성 날짜가 null이 아닙니다.");
+		Assertions.assertNotNull(comment.getUpdatedAt(), "수정 날짜가 null이 아닙니다.");
+		Assertions.assertEquals(comment.getCreatedAt(), comment.getUpdatedAt());
+	}
+
+	@Test
+	@Transactional
+	void merge시_수정_날짜_업데이트_된다() {
+		final Long id = commentService.save(new CommentRegisterCommand(1L, 2L, "테스트 댓글", List.of("image1.jpg", "image2.jpg")));
+		em.flush();
+		em.clear();
+
+		final Comment comment = commentRepository.findById(id)
+			.orElseThrow();
+
+		comment.setContent("수정된 댓글 내용");
+		em.flush();
+		em.clear();
+
+		final Comment updatedComment = commentRepository.findById(id)
+			.orElseThrow();
+		Assertions.assertNotEquals(comment.getCreatedAt(), updatedComment.getUpdatedAt());
+	}
+
+	@Test
+	@Transactional
+	void 영속성_컨텍스트내에서_이미지_수정시_반영_된다() {
+		final Long id = commentService.save(new CommentRegisterCommand(1L, 2L, "테스트 댓글", List.of("image1.jpg", "image2.jpg")));
+
+		em.flush();
+		em.clear();
+
+		final Comment comment = commentRepository.findById(id)
+			.orElseThrow();
+
+		comment.updateImages(List.of("image3.jpg"));
+		em.flush();
+		em.clear();
+
+		final Comment updatedComment = commentRepository.findById(id)
+			.orElseThrow();
+		Assertions.assertTrue(updatedComment.getImageSources().contains("image3.jpg"));
+		Assertions.assertEquals(1, updatedComment.getImageSources().size());
+	}
+}

--- a/domain/mathrank-board-comment/src/test/java/kr/co/mathrank/domain/board/comment/service/CommentServiceTest.java
+++ b/domain/mathrank-board-comment/src/test/java/kr/co/mathrank/domain/board/comment/service/CommentServiceTest.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import kr.co.mathrank.domain.board.comment.dto.CommentDeleteCommand;
 import kr.co.mathrank.domain.board.comment.dto.CommentRegisterCommand;
 import kr.co.mathrank.domain.board.comment.dto.CommentUpdateCommand;
 import kr.co.mathrank.domain.board.comment.entity.Comment;
@@ -139,5 +140,36 @@ class CommentServiceTest {
 		Assertions.assertEquals(updatedContent, updatedComment.getContent());
 		Assertions.assertTrue(updatedComment.getImageSources().contains(updatedImageSource));
 		Assertions.assertEquals(1, updatedComment.getImageSources().size());
+	}
+
+	@Test
+	@Transactional
+	void 소유자만_삭제가능() {
+		final long userId = 2L;
+		final long otherId = 3L;
+		final Long id = commentService.save(new CommentRegisterCommand(1L,
+			userId, "테스트 댓글", List.of("image1.jpg", "image2.jpg")));
+		em.flush();
+		em.clear();
+
+		Assertions.assertThrows(IllegalArgumentException.class, () -> commentService.delete(new CommentDeleteCommand(id, otherId)));
+	}
+
+	@Test
+	@Transactional
+	void 삭제_정상동작_확인() {
+		final long userId = 2L;
+		final Long id = commentService.save(new CommentRegisterCommand(1L,
+			userId, "테스트 댓글", List.of("image1.jpg", "image2.jpg")));
+
+		em.flush();
+		em.clear();
+
+		commentService.delete(new CommentDeleteCommand(id, userId));
+
+		em.flush();
+		em.clear();
+
+		Assertions.assertEquals(0, commentRepository.count());
 	}
 }

--- a/domain/mathrank-board-comment/src/test/java/kr/co/mathrank/domain/board/comment/service/CommentServiceTest.java
+++ b/domain/mathrank-board-comment/src/test/java/kr/co/mathrank/domain/board/comment/service/CommentServiceTest.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import jakarta.validation.ConstraintViolationException;
 import kr.co.mathrank.domain.board.comment.dto.CommentDeleteCommand;
 import kr.co.mathrank.domain.board.comment.dto.CommentRegisterCommand;
 import kr.co.mathrank.domain.board.comment.dto.CommentUpdateCommand;
@@ -171,5 +172,12 @@ class CommentServiceTest {
 		em.clear();
 
 		Assertions.assertEquals(0, commentRepository.count());
+	}
+
+	@Test
+	void 댓글_등록_시_형식에따른_예외() {
+		Assertions.assertThrows(ConstraintViolationException.class, () -> {
+			commentService.save(new CommentRegisterCommand(null, 2L, "테스트 댓글", List.of()));
+		});
 	}
 }

--- a/domain/mathrank-board-comment/src/test/resources/application.properties
+++ b/domain/mathrank-board-comment/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+snowflake.node.id=2
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,6 +11,7 @@ include(
         'client:out',
 
         'domain',
+        'domain:mathrank-board-comment',
 
         'common',
         'common:mathrank-dataserializer',


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
comment 등록 기능 구현입니다.

`@ID` 필드 수동 삽입으로 인해 `EntityManager`가 merge 대상으로 판단해 DB를 조회하는 불필요한 오버헤드가 있었습니다. 
이를 해결하기 위해, `Persistence` 인터페이스를 통해 바로 insert되도록 구현했습니다.

## 스크린샷 (선택)

> 이미지

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> `@ID` 필드 수동 삽입으로 인해 `EntityManager`가 merge 대상으로 판단해 DB를 조회하는 불필요한 오버헤드가 있었습니다. 
이를 해결하기 위해, `Persistence` 인터페이스를 통해 바로 insert되도록 구현했습니다.

### 📌 PR 진행 시 참고사항
- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)