### PR TITLE
feat(problem-single-read): 모델 삭제 기능 구현

### DIFF
--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelRepository.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelRepository.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -19,4 +20,6 @@ public interface SingleProblemReadModelRepository
 	@Query("SELECT sp FROM SingleProblemReadModel sp WHERE sp.id = :singleProblemId")
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	Optional<SingleProblemReadModel> findByIdForUpdate(@Param("singleProblemId") Long singleProblemId);
+
+	void deleteByProblemId(Long problemId);
 }

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemReadModelDeleteService.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemReadModelDeleteService.java
@@ -1,0 +1,27 @@
+package kr.co.mathrank.domain.problem.single.read.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.domain.problem.single.read.repository.SingleProblemReadModelRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@Validated
+@RequiredArgsConstructor
+public class SingleProblemReadModelDeleteService {
+	private final SingleProblemReadModelRepository singleProblemReadModelRepository;
+
+	public void deleteByProblemId(@NotNull final Long problemId) {
+		singleProblemReadModelRepository.deleteByProblemId(problemId);
+		log.info("[SingleProblemReadModelDeleteService.delete] read model deleted - problemId: {}", problemId);
+	}
+
+	public void deleteBySingleProblemId(@NotNull final Long singleProblemId) {
+		singleProblemReadModelRepository.deleteById(singleProblemId);
+		log.info("[SingleProblemReadModelDeleteService.delete] read model deleted - singleProblemId: {}", singleProblemId);
+	}
+}

--- a/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemReadModelDeleteServiceTest.java
+++ b/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemReadModelDeleteServiceTest.java
@@ -1,0 +1,131 @@
+package kr.co.mathrank.domain.problem.single.read.service;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import jakarta.persistence.EntityManager;
+import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.single.read.entity.SingleProblemReadModel;
+import kr.co.mathrank.domain.problem.single.read.repository.SingleProblemReadModelRepository;
+
+@SpringBootTest(
+	properties = {
+		"spring.jpa.show-sql=true",
+		"spring.jpa.hibernate.ddl-auto=create"
+	}
+)
+@Testcontainers
+@Transactional
+class SingleProblemReadModelDeleteServiceTest {
+	@Autowired
+	private SingleProblemReadModelDeleteService singleProblemReadModelDeleteService;
+	@Autowired
+	private SingleProblemReadModelRepository singleProblemReadModelRepository;
+	@Autowired
+	private EntityManager entityManager;
+
+	@Container
+	static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.42")
+		.withDatabaseName("testdb")
+		.withUsername("user")
+		.withPassword("password");
+
+	@DynamicPropertySource
+	static void setProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", mysql::getJdbcUrl);
+		registry.add("spring.datasource.username", mysql::getUsername);
+		registry.add("spring.datasource.password", mysql::getPassword);
+	}
+
+	@Test
+	void problemId로_삭제된다() {
+		final Long problemId = 1L;
+		final Long singleProblemId = 2L;
+		final LocalDateTime baseTime = LocalDateTime.of(2018, 1, 1, 1, 1);
+		final SingleProblemReadModel model = SingleProblemReadModel.of(singleProblemId, problemId, "img", "initialPath",
+			null, Difficulty.MID,
+			300L, 2000L, 1000L, baseTime);
+
+		singleProblemReadModelRepository.save(model);
+
+		entityManager.flush();
+		entityManager.clear();
+
+		singleProblemReadModelDeleteService.deleteByProblemId(problemId);
+
+		Assertions.assertEquals(0, singleProblemReadModelRepository.count());
+	}
+
+	@Test
+	void 일치하는_problemId_없어도_에러처리_안해() {
+		final Long problemId = 1L;
+		final Long singleProblemId = 2L;
+
+		// 존재 안하는애로 삭제
+		final Long notExistProblemId = 100L;
+
+		final LocalDateTime baseTime = LocalDateTime.of(2018, 1, 1, 1, 1);
+		final SingleProblemReadModel model = SingleProblemReadModel.of(singleProblemId, problemId, "img", "initialPath",
+			null, Difficulty.MID,
+			300L, 2000L, 1000L, baseTime);
+
+		singleProblemReadModelRepository.save(model);
+
+		entityManager.flush();
+		entityManager.clear();
+
+		// 존재 안하는 놈 삭제 시도
+		singleProblemReadModelDeleteService.deleteByProblemId(notExistProblemId);
+
+		Assertions.assertEquals(1, singleProblemReadModelRepository.count());
+	}
+
+	@Test
+	void singleProblemId로_삭제된다() {
+		final Long problemId = 1L;
+		final Long singleProblemId = 2L;
+		final LocalDateTime baseTime = LocalDateTime.of(2018, 1, 1, 1, 1);
+		final SingleProblemReadModel model = SingleProblemReadModel.of(singleProblemId, problemId, "img", "initialPath",
+			null, Difficulty.MID,
+			300L, 2000L, 1000L, baseTime);
+
+		singleProblemReadModelRepository.save(model);
+
+		entityManager.flush();
+		entityManager.clear();
+
+		singleProblemReadModelDeleteService.deleteBySingleProblemId(singleProblemId);
+
+		Assertions.assertEquals(0, singleProblemReadModelRepository.count());
+	}
+
+	@Test
+	void 일치하는_singleProblemId_없어도_에러처리_안해() {
+		final Long problemId = 1L;
+		final Long singleProblemId = 2L;
+		final Long notExistSingleProblemId = 100L;
+		final LocalDateTime baseTime = LocalDateTime.of(2018, 1, 1, 1, 1);
+		final SingleProblemReadModel model = SingleProblemReadModel.of(singleProblemId, problemId, "img", "initialPath",
+			null, Difficulty.MID,
+			300L, 2000L, 1000L, baseTime);
+
+		singleProblemReadModelRepository.save(model);
+
+		entityManager.flush();
+		entityManager.clear();
+
+		singleProblemReadModelDeleteService.deleteBySingleProblemId(notExistSingleProblemId);
+
+		Assertions.assertEquals(1, singleProblemReadModelRepository.count());
+	}
+}


### PR DESCRIPTION
## 📝 작업 내용
- `ProblemId`, `SingleProblemId` 모두로 삭제 가능하다.
- 없는 ID 삭제 시도는, 예외를 던지지 않고 항상 성공한다.