### PR TITLE
hotfix: 구현체와 인터페이스가 다른 제약을 가지고 있음으로 인한 에러 해결

### DIFF
--- a/common/mathrank-event-publisher-monolith/src/main/java/kr/co/mathrank/common/event/publisher/monolith/MonolithEventPublisher.java
+++ b/common/mathrank-event-publisher-monolith/src/main/java/kr/co/mathrank/common/event/publisher/monolith/MonolithEventPublisher.java
@@ -4,7 +4,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
-import jakarta.validation.constraints.NotNull;
 import kr.co.mathrank.common.event.publisher.EventPublishException;
 import kr.co.mathrank.common.event.publisher.EventPublisher;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +17,7 @@ public class MonolithEventPublisher implements EventPublisher {
 	private final ApplicationEventPublisher eventPublisher;
 
 	@Override
-	public void publish(@NotNull String topic, @NotNull String payload) throws EventPublishException {
+	public void publish(String topic, String payload) throws EventPublishException {
 		log.debug("[MonolithEventPublisher.publish] publishing event to monolith topic: {} payload: {}", topic, payload);
 		eventPublisher.publishEvent(new MonolithEvent(topic, payload));
 	}

--- a/common/mathrank-event-publisher/build.gradle
+++ b/common/mathrank-event-publisher/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+}

--- a/common/mathrank-event-publisher/src/main/java/kr/co/mathrank/common/event/publisher/EventPublisher.java
+++ b/common/mathrank-event-publisher/src/main/java/kr/co/mathrank/common/event/publisher/EventPublisher.java
@@ -1,5 +1,8 @@
 package kr.co.mathrank.common.event.publisher;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 /**
  * 메시지 브로커를 통한 이벤트 발행을 추상화한 인터페이스입니다.
  * <p>
@@ -21,9 +24,9 @@ public interface EventPublisher {
 	/**
 	 * 지정한 토픽으로 이벤트를 발행합니다.
 	 *
-	 * @param topic   브로커에서 구독하는 토픽 이름
-	 * @param payload 전송할 이벤트 데이터(직렬화된 문자열)
+	 * @param topic   브로커에서 구독하는 토픽 이름 not null
+	 * @param payload 전송할 이벤트 데이터(직렬화된 문자열) not null
 	 * @throws EventPublishException 발행 실패 시 발생
 	 */
-	void publish(String topic, String payload) throws EventPublishException;
+	void publish(@NotNull String topic, @NotNull String payload) throws EventPublishException;
 }


### PR DESCRIPTION
## 📝 작업 내용

- 상위 `EventPublisher`의 파라미터 제약과 구체 클래스 `MonolithEventPublisher`의 제약이 달라서 생기던 오류 해결 
