### PR TITLE
feat(single-problem): 특정 문제에 대한 풀이 기록 조회 API 구현

### DIFF
--- a/app/api/mathrank-problem-single-api/src/main/java/kr/co/mathrank/app/api/problem/single/controller/SingleProblemChallengeLogResponse.java
+++ b/app/api/mathrank-problem-single-api/src/main/java/kr/co/mathrank/app/api/problem/single/controller/SingleProblemChallengeLogResponse.java
@@ -1,0 +1,21 @@
+package kr.co.mathrank.app.api.problem.single.controller;
+
+import java.time.LocalDateTime;
+
+import kr.co.mathrank.domain.problem.single.dto.SingleProblemChallengeLogResult;
+
+public record SingleProblemChallengeLogResponse(
+	Long challengeLogId,
+	Boolean success,
+	LocalDateTime submittedAt,
+	Long elapsedTimeSeconds
+) {
+	public static SingleProblemChallengeLogResponse from(SingleProblemChallengeLogResult result) {
+		return new SingleProblemChallengeLogResponse(
+			result.challengeLogId(),
+			result.success(),
+			result.submittedAt(),
+			result.elapsedTime().toSeconds()
+		);
+	}
+}

--- a/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/dto/SingleProblemChallengeLogResult.java
+++ b/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/dto/SingleProblemChallengeLogResult.java
@@ -1,0 +1,22 @@
+package kr.co.mathrank.domain.problem.single.dto;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import kr.co.mathrank.domain.problem.single.entity.ChallengeLog;
+
+public record SingleProblemChallengeLogResult(
+	Long challengeLogId,
+	Boolean success,
+	LocalDateTime submittedAt,
+	Duration elapsedTime
+) {
+	public static SingleProblemChallengeLogResult from(final ChallengeLog challengeLog) {
+		return new SingleProblemChallengeLogResult(
+			challengeLog.getId(),
+			challengeLog.getSuccess(),
+			challengeLog.getChallengedAt(),
+			challengeLog.getElapsedTime()
+		);
+	}
+}

--- a/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/dto/SingleProblemChallengeLogResults.java
+++ b/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/dto/SingleProblemChallengeLogResults.java
@@ -1,0 +1,15 @@
+package kr.co.mathrank.domain.problem.single.dto;
+
+import java.util.List;
+
+import kr.co.mathrank.domain.problem.single.entity.ChallengeLog;
+
+public record SingleProblemChallengeLogResults(
+	List<SingleProblemChallengeLogResult> results
+) {
+	public static SingleProblemChallengeLogResults from(final List<ChallengeLog> challengeLogs) {
+		return new SingleProblemChallengeLogResults(challengeLogs.stream()
+			.map(SingleProblemChallengeLogResult::from)
+			.toList());
+	}
+}

--- a/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/service/ChallengerQueryService.java
+++ b/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/service/ChallengerQueryService.java
@@ -5,6 +5,8 @@ import org.springframework.validation.annotation.Validated;
 
 import jakarta.validation.constraints.NotNull;
 import kr.co.mathrank.domain.problem.single.dto.ChallengerQueryResults;
+import kr.co.mathrank.domain.problem.single.dto.SingleProblemChallengeLogResults;
+import kr.co.mathrank.domain.problem.single.exception.CannotFindChallengerException;
 import kr.co.mathrank.domain.problem.single.repository.ChallengerRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -16,5 +18,15 @@ public class ChallengerQueryService {
 
 	public ChallengerQueryResults findMemberChallenges(@NotNull final Long memberId) {
 		return new ChallengerQueryResults(challengerRepository.findByMemberId(memberId));
+	}
+
+	public SingleProblemChallengeLogResults findChallengeLogs(
+		@NotNull final Long requestMemberId,
+		@NotNull final Long singleProblemId
+	) {
+		return SingleProblemChallengeLogResults.from(
+			challengerRepository.findByMemberIdAndSingleProblemId(requestMemberId, singleProblemId)
+				.orElseThrow(CannotFindChallengerException::new)
+				.getChallengeLogs());
 	}
 }


### PR DESCRIPTION
#98 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint for authenticated users to retrieve their challenge attempt history for a specific single problem.
  * Responses include each attempt’s ID, success status, submission time, and elapsed time in seconds, enabling progress tracking and performance insights.
  * Designed for easy integration in client apps to display histories, timelines, or analytics for individual problems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->