### PR TITLE
feat(member): 내 계정 정보 조회 시, 학교 정보 디테일하게 리턴

### DIFF
--- a/app/api/mathrank-member-read-api/build.gradle
+++ b/app/api/mathrank-member-read-api/build.gradle
@@ -5,5 +5,6 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
     implementation project(':domain:mathrank-auth-domain')
+    implementation project(':client:external:mathrank-school')
     implementation project(':app:api:mathrank-api-common')
 }

--- a/app/api/mathrank-member-read-api/src/main/java/kr/co/mathrank/app/api/member/read/MemberDetailQueryController.java
+++ b/app/api/mathrank-member-read-api/src/main/java/kr/co/mathrank/app/api/member/read/MemberDetailQueryController.java
@@ -9,6 +9,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.mathrank.app.api.common.authentication.Authorization;
 import kr.co.mathrank.app.api.common.authentication.LoginInfo;
 import kr.co.mathrank.app.api.common.authentication.MemberPrincipal;
+import kr.co.mathrank.client.external.school.RequestType;
+import kr.co.mathrank.client.external.school.SchoolClient;
+import kr.co.mathrank.client.external.school.SchoolInfo;
 import kr.co.mathrank.domain.auth.dto.MemberInfoResult;
 import kr.co.mathrank.domain.auth.service.MemberQueryService;
 import lombok.RequiredArgsConstructor;
@@ -18,13 +21,18 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MemberDetailQueryController {
 	private final MemberQueryService memberQueryService;
+	private final SchoolClient schoolClient;
 
 	@GetMapping("/api/v1/member/info/my")
 	@Operation(summary = "내 계정 정보 조회 API", description = "내 계정의 정보를 조회합니다.")
 	@Authorization(openedForAll = true)
-	public ResponseEntity<MemberInfoResult> getMyInfo(
+	public ResponseEntity<Responses.MemberInfoDetailResponse> getMyInfo(
 		@LoginInfo final MemberPrincipal memberPrincipal
 	) {
-		return ResponseEntity.ok(memberQueryService.getInfo(memberPrincipal.memberId()));
+		final MemberInfoResult result = memberQueryService.getInfo(memberPrincipal.memberId());
+		final SchoolInfo schoolInfo = schoolClient.getSchool(RequestType.JSON.getType(), result.schoolCode())
+			.orElse(SchoolInfo.none());
+
+		return ResponseEntity.ok(Responses.MemberInfoDetailResponse.from(result, schoolInfo));
 	}
 }

--- a/app/api/mathrank-member-read-api/src/main/java/kr/co/mathrank/app/api/member/read/Responses.java
+++ b/app/api/mathrank-member-read-api/src/main/java/kr/co/mathrank/app/api/member/read/Responses.java
@@ -1,0 +1,50 @@
+package kr.co.mathrank.app.api.member.read;
+
+import java.time.LocalDateTime;
+
+import kr.co.mathrank.client.external.school.SchoolInfo;
+import kr.co.mathrank.common.role.Role;
+import kr.co.mathrank.domain.auth.dto.MemberInfoResult;
+import kr.co.mathrank.domain.auth.entity.MemberType;
+
+public class Responses {
+	record MemberInfoDetailResponse(
+		Long memberId,
+		String nickName,
+		Role role,
+		MemberType memberType,
+		LocalDateTime createdAt,
+		Boolean agreeToPrivacyPolicy,
+		Boolean pending,
+		SchoolResponse schoolDetail
+	) {
+		public static MemberInfoDetailResponse from(final MemberInfoResult result, final SchoolInfo schoolInfo) {
+			return new MemberInfoDetailResponse(
+				result.memberId(),
+				result.nickName(),
+				result.role(),
+				result.memberType(),
+				result.createdAt(),
+				result.agreeToPrivacyPolicy(),
+				result.pending(),
+				SchoolResponse.from(schoolInfo)
+			);
+		}
+	}
+
+	public record SchoolResponse(
+		String schoolName,
+		String schoolCode,
+		String schoolKind,
+		String schoolLocation
+	) {
+		public static SchoolResponse from(final SchoolInfo schoolInfo) {
+			return new SchoolResponse(
+				schoolInfo.SCHUL_NM(),
+				schoolInfo.SD_SCHUL_CODE(),
+				schoolInfo.SCHUL_KND_SC_NM(),
+				schoolInfo.ORG_RDNMA()
+			);
+		}
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * “My Info” now returns enriched member details including associated school information (name, code, type, location).
  * Response structure updated to combine member and school data for a more complete profile view.

* **Chores**
  * Added dependency on an external school client module to enable school data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->