### PR TITLE
fix(aws): release 브랜치에 대해서 배포되도록 수정

### DIFF
--- a/.github/workflows/code-deploy.yml
+++ b/.github/workflows/code-deploy.yml
@@ -3,7 +3,7 @@ name: Deploy via CodeDeploy
 on:
   push:
     branches:
-      - 'main'
+      - 'release/**'
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated CI/CD deployment trigger to run on any release/* branch instead of only the main branch, enabling more flexible, staged releases and hotfixes.
  - Build and deployment processes remain the same; no changes to application features or behavior.
  - No action required for users; this change only affects how releases are deployed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->