### PR TITLE
fix(id): 프론트에서 Number 타입으로 받음에 따라 유실 발생(부동소수점), 따라서 String 으로 전환해서 보내기~

### DIFF
--- a/app/api/mathrank-auth-api/src/main/java/kr/co/mathrank/app/api/auth/Responses.java
+++ b/app/api/mathrank-auth-api/src/main/java/kr/co/mathrank/app/api/auth/Responses.java
@@ -17,11 +17,11 @@ public class Responses {
 	}
 
 	public record MemberInfoResponse(
-		Long memberId,
+		String memberId,
 		String memberName
 	) {
 		public static MemberInfoResponse from(final MemberInfoResult result) {
-			return new MemberInfoResponse(result.memberId(), result.nickName());
+			return new MemberInfoResponse(String.valueOf(result.memberId()), result.nickName());
 		}
 	}
 }

--- a/app/api/mathrank-member-read-api/src/main/java/kr/co/mathrank/app/api/member/read/Responses.java
+++ b/app/api/mathrank-member-read-api/src/main/java/kr/co/mathrank/app/api/member/read/Responses.java
@@ -9,7 +9,7 @@ import kr.co.mathrank.domain.auth.entity.MemberType;
 
 public class Responses {
 	record MemberInfoDetailResponse(
-		Long memberId,
+		String memberId,
 		String nickName,
 		Role role,
 		MemberType memberType,
@@ -20,7 +20,7 @@ public class Responses {
 	) {
 		public static MemberInfoDetailResponse from(final MemberInfoResult result, final SchoolInfo schoolInfo) {
 			return new MemberInfoDetailResponse(
-				result.memberId(),
+				String.valueOf(result.memberId()),
 				result.nickName(),
 				result.role(),
 				result.memberType(),

--- a/app/api/mathrank-problem-assessment-api/src/main/java/kr/co/mathrank/app/api/assessment/AssessmentController.java
+++ b/app/api/mathrank-problem-assessment-api/src/main/java/kr/co/mathrank/app/api/assessment/AssessmentController.java
@@ -42,11 +42,12 @@ public class AssessmentController {
 	@Operation(summary = "문제집 답안지 등록 API")
 	@PostMapping("/api/v1/problem/assessment/submission")
 	@Authorization(openedForAll = true)
-	public ResponseEntity<Long> registerSubmission(
+	public ResponseEntity<String> registerSubmission(
 		@RequestBody @Valid final Requests.AssessmentSubmissionRegisterRequest request,
 		@LoginInfo final MemberPrincipal memberPrincipal
 	) {
 		final SubmissionRegisterCommand command = request.toCommand(memberPrincipal.memberId());
-		return ResponseEntity.status(HttpStatus.CREATED).body(submissionRegisterService.submit(command));
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(String.valueOf(submissionRegisterService.submit(command)));
 	}
 }

--- a/app/api/mathrank-problem-assessment-read-api/src/main/java/kr/co/mathrank/app/api/problem/assessment/Responses.java
+++ b/app/api/mathrank-problem-assessment-read-api/src/main/java/kr/co/mathrank/app/api/problem/assessment/Responses.java
@@ -8,11 +8,13 @@ import kr.co.mathrank.domain.problem.assessment.dto.AssessmentDetailReadModelRes
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentItemReadModelDetailResult;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentPageQueryResult;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentSubmissionRankResult;
+import kr.co.mathrank.domain.problem.assessment.dto.CourseDetailResult;
 import kr.co.mathrank.domain.problem.assessment.dto.SubmissionItemQueryResult;
 import kr.co.mathrank.domain.problem.assessment.dto.SubmissionQueryResult;
 import kr.co.mathrank.domain.problem.assessment.dto.SubmissionQueryResults;
 import kr.co.mathrank.domain.problem.assessment.entity.AssessmentPeriodType;
 import kr.co.mathrank.domain.problem.assessment.entity.EvaluationStatus;
+import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
 
 class Responses {
@@ -51,9 +53,9 @@ class Responses {
 	}
 
 	public record AssessmentSubmissionQueryResponse(
-		Long submissionId,
+		String submissionId,
 		Long assessmentAverageScore,
-		Long memberId,
+		String memberId,
 		EvaluationStatus evaluationStatus,
 		Integer totalScore,
 		List<SubmissionItemQueryResult> itemSubmissionResults,
@@ -62,9 +64,9 @@ class Responses {
 	) {
 		public static AssessmentSubmissionQueryResponse from(final SubmissionQueryResult result) {
 			return new AssessmentSubmissionQueryResponse(
-				result.submissionId(),
+				String.valueOf(result.submissionId()),
 				result.assessmentAverageScore(),
-				result.memberId(),
+				String.valueOf(result.memberId()),
 				result.evaluationStatus(),
 				result.totalScore(),
 				result.submissionItemQueryResults(),
@@ -75,9 +77,9 @@ class Responses {
 	}
 
 	public record AssessmentDetailResponse(
-		Long assessmentId,
-		List<AssessmentItemReadModelDetailResult> itemDetails,
-		Long registeredMemberId,
+		String assessmentId,
+		List<AssessmentItemReadModelDetailResponse> itemDetails,
+		String registeredMemberId,
 		String assessmentName,
 		Long distinctUserCount,
 		LocalDateTime createdAt,
@@ -86,9 +88,11 @@ class Responses {
 	) {
 		public static AssessmentDetailResponse from(AssessmentDetailReadModelResult result) {
 			return new AssessmentDetailResponse(
-				result.assessmentId(),
-				result.itemDetails(),
-				result.registeredMemberId(),
+				String.valueOf(result.assessmentId()),
+				result.itemDetails().stream()
+					.map(AssessmentItemReadModelDetailResponse::from)
+					.toList(),
+				String.valueOf(result.registeredMemberId()),
 				result.assessmentName(),
 				result.distinctUserCount(),
 				result.createdAt(),
@@ -98,9 +102,38 @@ class Responses {
 		}
 	}
 
+	public record AssessmentItemReadModelDetailResponse(
+		String problemId,
+		String problemImage,
+		String memberId,
+		Integer score,
+		CourseDetailResult courseDetailResult,
+		Difficulty difficulty,
+		AnswerType type,
+		String schoolCode,
+		LocalDateTime createdAt,
+		Integer year
+	) {
+		public static AssessmentItemReadModelDetailResponse from(final AssessmentItemReadModelDetailResult result) {
+			return new AssessmentItemReadModelDetailResponse(
+				String.valueOf(result.problemId()),
+				result.problemImage(),
+				String.valueOf(result.memberId()),
+				result.score(),
+				result.courseDetailResult(),
+				result.difficulty(),
+				result.type(),
+				result.schoolCode(),
+				result.createdAt(),
+				result.year()
+			);
+		}
+
+	}
+
 	public record AssessmentPageResponse(
-		Long assessmentId,
-		Long memberId,
+		String assessmentId,
+		String memberId,
 		String assessmentName,
 		Long distinctUserCount,
 		LocalDateTime createdAt,
@@ -110,8 +143,8 @@ class Responses {
 	) {
 		public static AssessmentPageResponse from(AssessmentPageQueryResult result) {
 			return new AssessmentPageResponse(
-				result.assessmentId(),
-				result.memberId(),
+				String.valueOf(result.assessmentId()),
+				String.valueOf(result.memberId()),
 				result.assessmentName(),
 				result.distinctUserCount(),
 				result.createdAt(),

--- a/app/api/mathrank-problem-contest-api/src/main/java/kr/co/mathrank/app/api/problem/contest/ContestController.java
+++ b/app/api/mathrank-problem-contest-api/src/main/java/kr/co/mathrank/app/api/problem/contest/ContestController.java
@@ -42,11 +42,12 @@ public class ContestController {
 	@Operation(summary = "대회 답안지 등록 API")
 	@PostMapping("/api/v1/problem/contest/submission")
 	@Authorization(openedForAll = true)
-	public ResponseEntity<Long> registerSubmission(
+	public ResponseEntity<String> registerSubmission(
 		@RequestBody @Valid final Requests.ContestSubmissionRegisterRequest request,
 		@LoginInfo final MemberPrincipal memberPrincipal
 	) {
 		final SubmissionRegisterCommand command = request.toCommand(memberPrincipal.memberId());
-		return ResponseEntity.status(HttpStatus.CREATED).body(submissionRegisterService.submit(command));
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(String.valueOf(submissionRegisterService.submit(command)));
 	}
 }

--- a/app/api/mathrank-problem-contest-read-api/src/main/java/kr/co/mathrank/app/api/problem/contest/Responses.java
+++ b/app/api/mathrank-problem-contest-read-api/src/main/java/kr/co/mathrank/app/api/problem/contest/Responses.java
@@ -8,10 +8,12 @@ import kr.co.mathrank.domain.problem.assessment.dto.AssessmentDetailReadModelRes
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentItemReadModelDetailResult;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentPageQueryResult;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentSubmissionRankResult;
+import kr.co.mathrank.domain.problem.assessment.dto.CourseDetailResult;
 import kr.co.mathrank.domain.problem.assessment.dto.SubmissionItemQueryResult;
 import kr.co.mathrank.domain.problem.assessment.dto.SubmissionQueryResult;
 import kr.co.mathrank.domain.problem.assessment.dto.SubmissionQueryResults;
 import kr.co.mathrank.domain.problem.assessment.entity.EvaluationStatus;
+import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
 
 class Responses {
@@ -48,9 +50,9 @@ class Responses {
 	}
 
 	public record ContestSubmissionQueryResponse(
-		Long submissionId,
+		String submissionId,
 		Long contestAverageScore,
-		Long memberId,
+		String memberId,
 		EvaluationStatus evaluationStatus,
 		Integer totalScore,
 		List<SubmissionItemQueryResult> itemSubmissionResults,
@@ -59,9 +61,9 @@ class Responses {
 	) {
 		public static ContestSubmissionQueryResponse from(final SubmissionQueryResult result) {
 			return new ContestSubmissionQueryResponse(
-				result.submissionId(),
+				String.valueOf(result.submissionId()),
 				result.assessmentAverageScore(),
-				result.memberId(),
+				String.valueOf(result.memberId()),
 				result.evaluationStatus(),
 				result.totalScore(),
 				result.submissionItemQueryResults(),
@@ -72,9 +74,9 @@ class Responses {
 	}
 
 	public record ContestDetailResponse(
-		Long contestId,
-		List<AssessmentItemReadModelDetailResult> itemDetails,
-		Long registeredMemberId,
+		String contestId,
+		List<ContestItemReadModelDetailResponse> itemDetails,
+		String registeredMemberId,
 		String contestName,
 		Long distinctUserCount,
 		LocalDateTime createdAt,
@@ -85,9 +87,11 @@ class Responses {
 	) {
 		public static ContestDetailResponse from(AssessmentDetailReadModelResult result) {
 			return new ContestDetailResponse(
-				result.assessmentId(),
-				result.itemDetails(),
-				result.registeredMemberId(),
+				String.valueOf(result.assessmentId()),
+				result.itemDetails().stream()
+					.map(ContestItemReadModelDetailResponse::from)
+					.toList(),
+				String.valueOf(result.registeredMemberId()),
 				result.assessmentName(),
 				result.distinctUserCount(),
 				result.createdAt(),
@@ -99,9 +103,38 @@ class Responses {
 		}
 	}
 
+	public record ContestItemReadModelDetailResponse(
+		String problemId,
+		String problemImage,
+		String memberId,
+		Integer score,
+		CourseDetailResult courseDetailResult,
+		Difficulty difficulty,
+		AnswerType type,
+		String schoolCode,
+		LocalDateTime createdAt,
+		Integer year
+	) {
+		public static ContestItemReadModelDetailResponse from(final AssessmentItemReadModelDetailResult result) {
+			return new ContestItemReadModelDetailResponse(
+				String.valueOf(result.problemId()),
+				result.problemImage(),
+				String.valueOf(result.memberId()),
+				result.score(),
+				result.courseDetailResult(),
+				result.difficulty(),
+				result.type(),
+				result.schoolCode(),
+				result.createdAt(),
+				result.year()
+			);
+		}
+
+	}
+
 	public record ContestPageResponse(
-		Long contestId,
-		Long memberId,
+		String contestId,
+		String memberId,
 		String contestName,
 		Long distinctUserCount,
 		LocalDateTime createdAt,
@@ -113,8 +146,8 @@ class Responses {
 	) {
 		public static ContestPageResponse from(AssessmentPageQueryResult result) {
 			return new ContestPageResponse(
-				result.assessmentId(),
-				result.memberId(),
+				String.valueOf(result.assessmentId()),
+				String.valueOf(result.memberId()),
 				result.assessmentName(),
 				result.distinctUserCount(),
 				result.createdAt(),

--- a/app/api/mathrank-problem-single-api/src/main/java/kr/co/mathrank/app/api/problem/single/controller/SingleProblemChallengeLogResponse.java
+++ b/app/api/mathrank-problem-single-api/src/main/java/kr/co/mathrank/app/api/problem/single/controller/SingleProblemChallengeLogResponse.java
@@ -6,7 +6,7 @@ import java.util.List;
 import kr.co.mathrank.domain.problem.single.dto.SingleProblemChallengeLogResult;
 
 public record SingleProblemChallengeLogResponse(
-	Long challengeLogId,
+	String challengeLogId,
 	Boolean success,
 	LocalDateTime submittedAt,
 	Long elapsedTimeSeconds,
@@ -15,7 +15,7 @@ public record SingleProblemChallengeLogResponse(
 ) {
 	public static SingleProblemChallengeLogResponse from(SingleProblemChallengeLogResult result) {
 		return new SingleProblemChallengeLogResponse(
-			result.challengeLogId(),
+			String.valueOf(result.challengeLogId()),
 			result.success(),
 			result.submittedAt(),
 			result.elapsedTime().toSeconds(),

--- a/app/api/mathrank-problem-single-api/src/main/java/kr/co/mathrank/app/api/problem/single/controller/SingleProblemController.java
+++ b/app/api/mathrank-problem-single-api/src/main/java/kr/co/mathrank/app/api/problem/single/controller/SingleProblemController.java
@@ -40,14 +40,14 @@ public class SingleProblemController {
 	@Operation(summary = "개별 문제 풀이 API", description = "해당 사용자의 문제풀이를 채점하고, 결과를 저장합니다. 풀이 결과는 모두 저장됩니다")
 	@PostMapping("/api/v1/problem/single/solve")
 	@Authorization(openedForAll = true)
-	public ResponseEntity<SingleProblemSolveResult> solveSingleProblem(
+	public ResponseEntity<SingleProblemSolveResponse> solveSingleProblem(
 		@ModelAttribute @ParameterObject @Valid final SingleProblemSolveRequest request,
 		@LoginInfo final MemberPrincipal memberPrincipal
 	) {
 		final SingleProblemSolveCommand command = request.toCommand(memberPrincipal.memberId());
 		final SingleProblemSolveResult result = singleProblemService.solve(command);
 
-		return ResponseEntity.ok(result);
+		return ResponseEntity.ok(SingleProblemSolveResponse.from(result));
 	}
 
 	@Operation(summary = "개별 문제 등록 API", description = "특정 문제를 개별문제로 등록합니다. 문제 중복 등록 시도시, 거부됩니다.")

--- a/app/api/mathrank-problem-single-api/src/main/java/kr/co/mathrank/app/api/problem/single/controller/SingleProblemSolveResponse.java
+++ b/app/api/mathrank-problem-single-api/src/main/java/kr/co/mathrank/app/api/problem/single/controller/SingleProblemSolveResponse.java
@@ -1,0 +1,22 @@
+package kr.co.mathrank.app.api.problem.single.controller;
+
+import java.util.List;
+import java.util.Set;
+
+import kr.co.mathrank.domain.problem.single.dto.SingleProblemSolveResult;
+
+public record SingleProblemSolveResponse(
+	String challengeLogId,
+	Boolean success,
+	Set<String> realAnswer,
+	List<String> submittedAnswer
+) {
+	public static SingleProblemSolveResponse from(final SingleProblemSolveResult result) {
+		return new SingleProblemSolveResponse(
+			String.valueOf(result.challengeLogId()),
+			result.success(),
+			result.realAnswer(),
+			result.submittedAnswer()
+		);
+	}
+}

--- a/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemReadModelResponse.java
+++ b/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemReadModelResponse.java
@@ -6,9 +6,9 @@ import kr.co.mathrank.domain.problem.core.Difficulty;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelResult;
 
 public record SingleProblemReadModelResponse(
-	Long id, // single problem id
+	String id, // single problem id
 	Boolean successAtFirstTry, // null: 푼적 없음, true: 성공해썽, false: 실패해썽
-	Long problemId, // problem id
+	String problemId, // problem id
 	String singleProblemName,
 	String problemImage,
 
@@ -23,9 +23,9 @@ public record SingleProblemReadModelResponse(
 ) {
 	public static SingleProblemReadModelResponse of(SingleProblemReadModelResult result, CourseQueryContainsParentsResult courseInfo) {
 		return new SingleProblemReadModelResponse(
-			result.id(),
+			String.valueOf(result.id()),
 			result.successAtFirstTry(),
-			result.problemId(),
+			String.valueOf(result.problemId()),
 			result.singleProblemName(),
 			result.problemImage(),
 			courseInfo,

--- a/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SolveStatusResponse.java
+++ b/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SolveStatusResponse.java
@@ -6,18 +6,20 @@ import kr.co.mathrank.domain.problem.single.read.dto.SolveStatusResult;
 import kr.co.mathrank.domain.problem.single.read.dto.SolveStatusResults;
 
 public record SolveStatusResponse(
-	List<Long> solvedSingleProblemIds,
-	List<Long> failedSingleProblemIds
+	List<String> solvedSingleProblemIds,
+	List<String> failedSingleProblemIds
 ) {
 	public static SolveStatusResponse from(final SolveStatusResults solveStatusResults) {
 		return new SolveStatusResponse(
 			solveStatusResults.solveStatusResults().stream()
 				.filter(SolveStatusResult::success)
 				.map(SolveStatusResult::singleProblemId)
+				.map(String::valueOf)
 				.toList(),
 			solveStatusResults.solveStatusResults().stream()
 				.filter(solveStatusResult -> !solveStatusResult.success())
 				.map(SolveStatusResult::singleProblemId)
+				.map(String::valueOf)
 				.toList()
 		);
 	}

--- a/app/api/mathrank-rank-read-api/src/main/java/kr/co/mathrank/rank/read/RankPageItemResponse.java
+++ b/app/api/mathrank-rank-read-api/src/main/java/kr/co/mathrank/rank/read/RankPageItemResponse.java
@@ -24,11 +24,11 @@ public record RankPageItemResponse(
 	}
 
 	record MemberResponse(
-		Long memberId,
+		String memberId,
 		String nickName
 	) {
 		static MemberResponse from(MemberInfo memberInfo) {
-			return new MemberResponse(memberInfo.memberId(), memberInfo.memberName());
+			return new MemberResponse(String.valueOf(memberInfo.memberId()), memberInfo.memberName());
 		}
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Richer per-item details in assessment and contest read responses.
  - New SingleProblemSolveResponse wrapper for solve results.

- Refactor
  - Standardized all API IDs to strings across auth, member, assessment, contest, single-problem, and rank endpoints.
  - Submission registration endpoints now return string IDs.
  - Challenge log ID and solve-status lists now use string IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->