### PR TITLE
feat(oauth-naver): 네이버 oAuth 클라이언트 추가

### DIFF
--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverConfiguration.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverConfiguration.java
@@ -1,0 +1,20 @@
+package kr.co.mathrank.domain.auth.client;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Configuration
+@Getter
+@Setter
+@ConfigurationProperties("oauth.naver")
+@ConditionalOnProperty(prefix = "oauth.naver", name = "clientId")
+@ToString(exclude = "clientSecret")
+class NaverConfiguration {
+	private String clientId;
+	private String clientSecret;
+}

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverMemberInfoResponse.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverMemberInfoResponse.java
@@ -1,0 +1,16 @@
+package kr.co.mathrank.domain.auth.client;
+
+record NaverMemberInfoResponse(
+	NaverResponse response
+) implements MemberInfoResponse {
+	@Override
+	public MemberInfo toInfo() {
+		return new MemberInfo(response.id(), response.nickname());
+	}
+
+	record NaverResponse(
+		String nickname,
+		Long id
+	) {
+	}
+}

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverOAuthClient.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverOAuthClient.java
@@ -9,7 +9,9 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 class NaverOAuthClient implements OAuthClientHandler {
+	// 토큰 발급 URI
 	private static final String TOKEN_URL = "https://nid.naver.com/oauth2.0/token";
+	// 사용자 정보 조회 URI
 	private static final String USER_INFO_URL = "https://openapi.naver.com/v1/nid/me";
 
 	private final NaverConfiguration naverConfiguration;

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverOAuthClient.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverOAuthClient.java
@@ -1,0 +1,59 @@
+package kr.co.mathrank.domain.auth.client;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import kr.co.mathrank.domain.auth.dto.MemberInfoResult;
+import kr.co.mathrank.domain.auth.dto.OAuthLoginCommand;
+import kr.co.mathrank.domain.auth.entity.OAuthProvider;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+class NaverOAuthClient implements OAuthClientHandler {
+	private static final String TOKEN_URL = "https://nid.naver.com/oauth2.0/token";
+	private static final String USER_INFO_URL = "https://openapi.naver.com/v1/nid/me";
+
+	private final NaverConfiguration naverConfiguration;
+
+	private final RestClient tokenClient = RestClient.builder()
+		.baseUrl(TOKEN_URL)
+		.build();
+
+	private final RestClient infoClient = RestClient.builder()
+		.baseUrl(USER_INFO_URL)
+		.build();
+
+	@Override
+	public MemberInfoResponse getMemberInfo(OAuthLoginCommand command) {
+		return getUserInfo(getAccessToken(command).access_token());
+	}
+
+	private AccessTokenResponse getAccessToken(final OAuthLoginCommand command) {
+		return tokenClient.post()
+			.uri(uriBuilder -> uriBuilder
+				.queryParam("grant_type", "authorization_code")
+				.queryParam("client_id", naverConfiguration.getClientId())
+				.queryParam("client_secret", naverConfiguration.getClientSecret())
+				.queryParam("code", command.code())
+				.queryParam("state", command.state())
+				.build())
+			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+			.retrieve()
+			.body(AccessTokenResponse.class);
+	}
+
+	private MemberInfoResponse getUserInfo(final String accessToken) {
+		final String headerValue = "Bearer " + accessToken;
+		return infoClient.get()
+			.header("Authorization", headerValue)
+			.retrieve()
+			.body(NaverMemberInfoResponse.class);
+	}
+
+	@Override
+	public boolean supports(OAuthProvider provider) {
+		return OAuthProvider.NAVER.equals(provider);
+	}
+}

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverOAuthClient.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverOAuthClient.java
@@ -1,5 +1,6 @@
 package kr.co.mathrank.domain.auth.client;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.web.client.RestClient;
 
@@ -9,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 class NaverOAuthClient implements OAuthClientHandler {
+	private static final String TOKEN_FORMAT = "Bearer %s";
 	// 토큰 발급 URI
 	private static final String TOKEN_URL = "https://nid.naver.com/oauth2.0/token";
 	// 사용자 정보 조회 URI
@@ -44,11 +46,11 @@ class NaverOAuthClient implements OAuthClientHandler {
 	}
 
 	private MemberInfoResponse getUserInfo(final String accessToken) {
-		final String headerValue = "Bearer " + accessToken;
-		return infoClient.get()
-			.header("Authorization", headerValue)
+		return infoClient.post()
+			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+			.header(HttpHeaders.AUTHORIZATION, TOKEN_FORMAT.formatted(accessToken))
 			.retrieve()
-			.body(NaverMemberInfoResponse.class);
+			.body(KakaoMemberInfoResponse.class);
 	}
 
 	@Override

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverOAuthClient.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverOAuthClient.java
@@ -1,15 +1,12 @@
 package kr.co.mathrank.domain.auth.client;
 
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
-import kr.co.mathrank.domain.auth.dto.MemberInfoResult;
 import kr.co.mathrank.domain.auth.dto.OAuthLoginCommand;
 import kr.co.mathrank.domain.auth.entity.OAuthProvider;
 import lombok.RequiredArgsConstructor;
 
-@Component
 @RequiredArgsConstructor
 class NaverOAuthClient implements OAuthClientHandler {
 	private static final String TOKEN_URL = "https://nid.naver.com/oauth2.0/token";

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/OAuthConfiguration.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/OAuthConfiguration.java
@@ -16,4 +16,11 @@ class OAuthConfiguration {
 		log.info("[OAuthClientConfiguration] kakao oauth client registered - configuration: {}", configuration);
 		return new KakaoOAuthClient(configuration);
 	}
+
+	@Bean
+	@ConditionalOnBean(NaverConfiguration.class)
+	NaverOAuthClient naverOAuthClient(final NaverConfiguration configuration) {
+		log.info("[OAuthClientConfiguration] naver oauth client registered - configuration: {}", configuration);
+		return new NaverOAuthClient(configuration);
+	}
 }

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/entity/OAuthProvider.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/entity/OAuthProvider.java
@@ -1,5 +1,6 @@
 package kr.co.mathrank.domain.auth.entity;
 
 public enum OAuthProvider {
-	KAKAO
+	KAKAO,
+	NAVER
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Users can now sign in with Naver; Naver account profiles are mapped to user accounts for seamless login.

- **Security**
  - Naver OAuth secrets are excluded from logs to protect sensitive credentials.

- **Configuration**
  - Naver login activates when the corresponding OAuth settings are provided in the service configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->