### PR TITLE
feat(single-problem-read): single read 도메인에서 클라이언트 호출 캐시 처리

### DIFF
--- a/app/api/mathrank-problem-single-read-api/build.gradle
+++ b/app/api/mathrank-problem-single-read-api/build.gradle
@@ -7,7 +7,6 @@ dependencies {
     implementation project(':domain:mathrank-problem-core-domain')
 
     implementation project(':app:api:mathrank-api-common')
-    implementation project(':client:internal:mathrank-course-client')
 
     implementation project(':common:mathrank-page')
 }

--- a/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemReadModelResponse.java
+++ b/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemReadModelResponse.java
@@ -1,9 +1,9 @@
 package kr.co.mathrank.app.api.problem.single.read;
 
-import kr.co.mathrank.client.internal.course.CourseQueryContainsParentsResult;
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
-import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelResult;
+import kr.co.mathrank.domain.problem.single.read.dto.CourseContainsParentResult;
+import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelQueryResult;
 
 public record SingleProblemReadModelResponse(
 	String id, // single problem id
@@ -12,7 +12,7 @@ public record SingleProblemReadModelResponse(
 	String singleProblemName,
 	String problemImage,
 
-	CourseQueryContainsParentsResult courseInfo,
+	CourseContainsParentResult courseInfo,
 
 	AnswerType answerType,
 	Difficulty difficulty,
@@ -21,14 +21,14 @@ public record SingleProblemReadModelResponse(
 	Long attemptedUserDistinctCount, // 해당 문제를 풀려고 한 사용자 수
 	Double accuracy // 정답률
 ) {
-	public static SingleProblemReadModelResponse of(SingleProblemReadModelResult result, CourseQueryContainsParentsResult courseInfo) {
+	public static SingleProblemReadModelResponse of(SingleProblemReadModelQueryResult result) {
 		return new SingleProblemReadModelResponse(
 			String.valueOf(result.id()),
 			result.successAtFirstTry(),
 			String.valueOf(result.problemId()),
 			result.singleProblemName(),
 			result.problemImage(),
-			courseInfo,
+			result.courseInfo(),
 			result.answerType(),
 			result.difficulty(),
 			result.firstTrySuccessCount(),

--- a/domain/mathrank-problem-single-read-domain/build.gradle
+++ b/domain/mathrank-problem-single-read-domain/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation project(':domain:mathrank-problem-core-domain')
     implementation project(':client:internal:mathrank-course-client')
 
+    implementation project(':common:mathrank-cache')
     implementation project(':common:mathrank-page')
     implementation project(':common:mathrank-exception')
     implementation project(':common:mathrank-querydsl')

--- a/domain/mathrank-problem-single-read-domain/build.gradle
+++ b/domain/mathrank-problem-single-read-domain/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     implementation project(':domain:mathrank-problem-core-domain')
+    implementation project(':client:internal:mathrank-course-client')
 
     implementation project(':common:mathrank-page')
     implementation project(':common:mathrank-exception')

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/SingleProblemReadModelConfiguration.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/SingleProblemReadModelConfiguration.java
@@ -1,0 +1,37 @@
+package kr.co.mathrank.domain.problem.single.read;
+
+import java.time.Duration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import kr.co.mathrank.common.cache.RequiredCacheSpec;
+
+@Configuration
+public class SingleProblemReadModelConfiguration {
+	public static final String COURSE_CACHE = "mathrank::domain::single-problem::read::course";
+
+	@Bean
+	RequiredCacheSpec courseCacheSpec() {
+		return cacheSpec(COURSE_CACHE, Duration.ofSeconds(30));
+	}
+
+	private RequiredCacheSpec cacheSpec(final String cacheName, final Duration ttl) {
+		return new RequiredCacheSpec() {
+			@Override
+			public String moduleName() {
+				return "single-problem-read-model-domain";
+			}
+
+			@Override
+			public String cacheName() {
+				return cacheName;
+			}
+
+			@Override
+			public Duration ttl() {
+				return ttl;
+			}
+		};
+	}
+}

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/CourseContainsParentResult.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/CourseContainsParentResult.java
@@ -1,0 +1,23 @@
+package kr.co.mathrank.domain.problem.single.read.dto;
+
+import java.util.List;
+
+import kr.co.mathrank.client.internal.course.CourseQueryContainsParentsResult;
+
+public record CourseContainsParentResult(
+	CourseInfoResult target,
+	List<CourseInfoResult> parents
+) {
+	public static CourseContainsParentResult from(CourseQueryContainsParentsResult result) {
+		return new CourseContainsParentResult(
+			CourseInfoResult.from(result.target()),
+			result.parents().stream()
+				.map(CourseInfoResult::from)
+				.toList()
+		);
+	}
+
+	public static CourseContainsParentResult none() {
+		return new CourseContainsParentResult(null, null);
+	}
+}

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/CourseInfoResult.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/CourseInfoResult.java
@@ -1,0 +1,12 @@
+package kr.co.mathrank.domain.problem.single.read.dto;
+
+import kr.co.mathrank.client.internal.course.CourseQueryResult;
+
+public record CourseInfoResult(
+	String coursePath,
+	String courseName
+) {
+	public static CourseInfoResult from(final CourseQueryResult courseQueryResult) {
+		return new CourseInfoResult(courseQueryResult.coursePath(), courseQueryResult.courseName());
+	}
+}

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemReadModelQueryResult.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemReadModelQueryResult.java
@@ -1,0 +1,67 @@
+package kr.co.mathrank.domain.problem.single.read.dto;
+
+import kr.co.mathrank.domain.problem.core.AnswerType;
+import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.single.read.entity.SingleProblemReadModel;
+
+public record SingleProblemReadModelQueryResult(
+	Long id, // single problem id
+	Boolean successAtFirstTry, // null: 푼적 없음, true: 성공해썽, false: 실패해썽
+	Long problemId, // problem id
+	String singleProblemName,
+	String problemImage,
+	CourseContainsParentResult courseInfo,
+	String location,
+	String schoolCode,
+	AnswerType answerType,
+	Difficulty difficulty,
+	Long firstTrySuccessCount, // 첫번째 시도에서 성공한 횟수
+	Long totalAttemptedCount, // 문제를 풀려고 시도한 총 횟수
+	Long attemptedUserDistinctCount, // 해당 문제를 풀려고 한 사용자 수
+	Double accuracy // 정답률
+) {
+	public static SingleProblemReadModelQueryResult from(
+		final SingleProblemReadModel model,
+		final CourseContainsParentResult courseContainsParentResult,
+		final Boolean successAtFirstTry
+	) {
+		return new SingleProblemReadModelQueryResult(
+			model.getId(),
+			successAtFirstTry,
+			model.getProblemId(),
+			model.getSingleProblemName(),
+			model.getProblemImage(),
+			courseContainsParentResult,
+			model.getLocation(),
+			model.getSchoolCode(),
+			model.getAnswerType(),
+			model.getDifficulty(),
+			model.getFirstTrySuccessCount(),
+			model.getTotalAttemptedCount(),
+			model.getAttemptedUserDistinctCount(),
+			model.getAccuracy()
+		);
+	}
+
+	public static SingleProblemReadModelQueryResult from(
+		final SingleProblemReadModelResult model,
+		final CourseContainsParentResult courseQueryResult
+	) {
+		return new SingleProblemReadModelQueryResult(
+			model.id(),
+			model.successAtFirstTry(),
+			model.problemId(),
+			model.singleProblemName(),
+			model.problemImage(),
+			courseQueryResult,
+			model.location(),
+			model.schoolCode(),
+			model.answerType(),
+			model.difficulty(),
+			model.firstTrySuccessCount(),
+			model.totalAttemptedCount(),
+			model.attemptedUserDistinctCount(),
+			model.accuracy()
+		);
+	}
+}

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/CourseManager.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/CourseManager.java
@@ -1,5 +1,9 @@
 package kr.co.mathrank.domain.problem.single.read.service;
 
+import static kr.co.mathrank.domain.problem.single.read.SingleProblemReadModelConfiguration.*;
+
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 
 import jakarta.validation.constraints.NotNull;
@@ -9,10 +13,12 @@ import kr.co.mathrank.domain.problem.single.read.dto.CourseContainsParentResult;
 import lombok.RequiredArgsConstructor;
 
 @Component
+@CacheConfig(cacheNames = COURSE_CACHE)
 @RequiredArgsConstructor
 class CourseManager {
 	private final CourseClient courseClient;
 
+	@Cacheable(key = "#coursePath")
 	public CourseContainsParentResult courseQueryResult(@NotNull final String coursePath) {
 		final CourseQueryContainsParentsResult result = courseClient.getParentCourses(coursePath);
 		return result == null ? CourseContainsParentResult.none() : CourseContainsParentResult.from(result);

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/CourseManager.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/CourseManager.java
@@ -1,0 +1,20 @@
+package kr.co.mathrank.domain.problem.single.read.service;
+
+import org.springframework.stereotype.Component;
+
+import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.client.internal.course.CourseClient;
+import kr.co.mathrank.client.internal.course.CourseQueryContainsParentsResult;
+import kr.co.mathrank.domain.problem.single.read.dto.CourseContainsParentResult;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+class CourseManager {
+	private final CourseClient courseClient;
+
+	public CourseContainsParentResult courseQueryResult(@NotNull final String coursePath) {
+		final CourseQueryContainsParentsResult result = courseClient.getParentCourses(coursePath);
+		return result == null ? CourseContainsParentResult.none() : CourseContainsParentResult.from(result);
+	}
+}

--- a/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemReadModelTest.java
+++ b/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemReadModelTest.java
@@ -20,13 +20,7 @@ import kr.co.mathrank.domain.problem.core.Difficulty;
 import kr.co.mathrank.domain.problem.single.read.repository.SingleProblemReadModelRepository;
 
 @Transactional
-@SpringBootTest(
-	properties =
-"""
-spring.jpa.show-sql=true
-spring.jpa.hibernate.ddl-auto=create
-"""
-)
+@SpringBootTest
 @Testcontainers
 class SingleProblemReadModelTest {
 	@Autowired

--- a/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelRepositoryTest.java
+++ b/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelRepositoryTest.java
@@ -10,11 +10,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import kr.co.mathrank.client.internal.course.CourseClient;
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelQuery;
@@ -23,15 +25,11 @@ import kr.co.mathrank.domain.problem.single.read.entity.OrderDirection;
 import kr.co.mathrank.domain.problem.single.read.entity.SingleProblemReadModel;
 
 @Transactional
-@SpringBootTest(
-	properties =
-		"""
-			spring.jpa.show-sql=true
-			spring.jpa.hibernate.ddl-auto=create
-			"""
-)
+@SpringBootTest
 @Testcontainers
 class SingleProblemReadModelRepositoryTest {
+	@MockitoBean
+	private CourseClient courseClient;
 	@Autowired
 	private SingleProblemReadModelRepository singleProblemReadModelRepository;
 

--- a/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemReadModelDeleteServiceTest.java
+++ b/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemReadModelDeleteServiceTest.java
@@ -18,12 +18,7 @@ import kr.co.mathrank.domain.problem.core.Difficulty;
 import kr.co.mathrank.domain.problem.single.read.entity.SingleProblemReadModel;
 import kr.co.mathrank.domain.problem.single.read.repository.SingleProblemReadModelRepository;
 
-@SpringBootTest(
-	properties = {
-		"spring.jpa.show-sql=true",
-		"spring.jpa.hibernate.ddl-auto=create"
-	}
-)
+@SpringBootTest
 @Testcontainers
 @Transactional
 class SingleProblemReadModelDeleteServiceTest {

--- a/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemReadModelRegisterServiceTest.java
+++ b/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemReadModelRegisterServiceTest.java
@@ -17,12 +17,7 @@ import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelRegisterCommand;
 
-@SpringBootTest(
-	properties = {
-		"spring.jpa.show-sql=true",
-		"spring.jpa.hibernate.ddl-auto=create"
-	}
-)
+@SpringBootTest
 @Testcontainers
 @Transactional
 class SingleProblemReadModelRegisterServiceTest {

--- a/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemUpdateServiceTest.java
+++ b/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemUpdateServiceTest.java
@@ -27,12 +27,7 @@ import kr.co.mathrank.domain.problem.single.read.entity.SingleProblemReadModel;
 import kr.co.mathrank.domain.problem.single.read.exception.CannotFoundProblemException;
 import kr.co.mathrank.domain.problem.single.read.repository.SingleProblemReadModelRepository;
 
-@SpringBootTest(
-	properties = {
-		"spring.jpa.show-sql=true",
-		"spring.jpa.hibernate.ddl-auto=create"
-	}
-)
+@SpringBootTest
 @Testcontainers
 class SingleProblemUpdateServiceTest {
 	@Autowired

--- a/domain/mathrank-problem-single-read-domain/src/test/resources/application.properties
+++ b/domain/mathrank-problem-single-read-domain/src/test/resources/application.properties
@@ -1,0 +1,6 @@
+spring.jpa.show-sql=true
+spring.jpa.hibernate.ddl-auto=create
+client.course.read-timeout-seconds=10
+client.course.connection-timeout-seconds=10
+client.course.port=11
+client.course.host=1d


### PR DESCRIPTION
- api 모듈은 연결 역할만 수행하도록 도메인 모듈로 클라이언트 호출 로직 분리
- 클라이언트 캐시 구성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Problem detail and list responses now include course information (with parent courses) and new stats: first-try success count, total attempts, distinct solvers, and accuracy.

- Refactor
  - Consolidated data flow to embed course info directly in responses and added caching for faster course lookups.

- Tests
  - Simplified test configuration, centralized JPA settings, and introduced client mocking for stability.

- Chores
  - Adjusted module dependencies and cleaned up unused client references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->