### PR TITLE
feat(board): 게시글 삭제 기능 구현

### DIFF
--- a/domain/mathrank-board-domain/build.gradle
+++ b/domain/mathrank-board-domain/build.gradle
@@ -1,5 +1,9 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    implementation project(':common:mathrank-role')
+    implementation project(':common:mathrank-exception')
+
     testRuntimeOnly 'com.h2database:h2'
 }

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/dto/PostDeleteCommand.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/dto/PostDeleteCommand.java
@@ -1,0 +1,14 @@
+package kr.co.mathrank.domain.board.dto;
+
+import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.common.role.Role;
+
+public record PostDeleteCommand(
+	@NotNull
+	Long postId,
+	@NotNull
+	Long memberId,
+	@NotNull
+	Role role
+) {
+}

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/exception/CannotDeletePostException.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/exception/CannotDeletePostException.java
@@ -1,0 +1,7 @@
+package kr.co.mathrank.domain.board.exception;
+
+public class CannotDeletePostException extends PostException {
+	public CannotDeletePostException() {
+		super(9002, "게시글을 삭제할 수 있는 권한 부재");
+	}
+}

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/exception/CannotFoundPostException.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/exception/CannotFoundPostException.java
@@ -1,0 +1,7 @@
+package kr.co.mathrank.domain.board.exception;
+
+public class CannotFoundPostException extends PostException {
+	public CannotFoundPostException() {
+		super(9001, "게시글을 찾을 수 없음");
+	}
+}

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/exception/PostException.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/exception/PostException.java
@@ -1,0 +1,9 @@
+package kr.co.mathrank.domain.board.exception;
+
+import kr.co.mathrank.common.exception.MathRankException;
+
+public class PostException extends MathRankException {
+	public PostException(int code, String message) {
+		super(code, message);
+	}
+}

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/service/PostDeleteService.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/service/PostDeleteService.java
@@ -1,0 +1,55 @@
+package kr.co.mathrank.domain.board.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.common.role.Role;
+import kr.co.mathrank.domain.board.dto.PostDeleteCommand;
+import kr.co.mathrank.domain.board.entity.Post;
+import kr.co.mathrank.domain.board.exception.CannotFoundPostException;
+import kr.co.mathrank.domain.board.exception.CannotDeletePostException;
+import kr.co.mathrank.domain.board.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@Validated
+@RequiredArgsConstructor
+public class PostDeleteService {
+	private final PostRepository postRepository;
+
+	@Transactional
+	public void delete(@NotNull @Valid final PostDeleteCommand command) {
+		final Post post = getPost(command.postId());
+
+		if (isOwner(command.role(), command.memberId(), post)) {
+			postRepository.delete(post);
+			log.info("[PostDeleteService.delete] post deleted - postId: {}, requestMemberId: {}, requestMemberRole: {}", post.getId(), command.memberId(), command.role());
+			return;
+		}
+		log.info("[PostDeleteService.delete] post not deleted - postId: {}, requestMemberId: {}, requestMemberRole: {}", post.getId(), command.memberId(), command.role());
+		throw new CannotDeletePostException();
+	}
+
+	private Post getPost(final Long postId) {
+		return postRepository.findById(postId)
+			.orElseThrow(() -> {
+				log.info("[PostDeleteService.delete] cannot found post - postId: {}", postId);
+				return new CannotFoundPostException();
+			});
+	}
+
+	private boolean isOwner(final Role role, final Long requestMemberId, final Post post) {
+		// 주인장이면 통과!
+		if (role == Role.ADMIN) {
+			return true;
+		}
+
+		// 일반 사용자일 경우 본인 글만 지울 수 있음
+		return requestMemberId.equals(post.getUserId());
+	}
+}

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/service/PostDeleteService.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/service/PostDeleteService.java
@@ -50,6 +50,6 @@ public class PostDeleteService {
 		}
 
 		// 일반 사용자일 경우 본인 글만 지울 수 있음
-		return requestMemberId.equals(post.getUserId());
+		return requestMemberId.equals(post.getMemberId());
 	}
 }

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/service/PostDeleteService.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/service/PostDeleteService.java
@@ -26,13 +26,12 @@ public class PostDeleteService {
 	public void delete(@NotNull @Valid final PostDeleteCommand command) {
 		final Post post = getPost(command.postId());
 
-		if (isOwner(command.role(), command.memberId(), post)) {
-			postRepository.delete(post);
-			log.info("[PostDeleteService.delete] post deleted - postId: {}, requestMemberId: {}, requestMemberRole: {}", post.getId(), command.memberId(), command.role());
-			return;
+		if (!isOwner(command.role(), command.memberId(), post)) {
+			log.info("[PostDeleteService.delete] post not deleted - postId: {}, requestMemberId: {}, requestMemberRole: {}", post.getId(), command.memberId(), command.role());
+			throw new CannotDeletePostException();
 		}
-		log.info("[PostDeleteService.delete] post not deleted - postId: {}, requestMemberId: {}, requestMemberRole: {}", post.getId(), command.memberId(), command.role());
-		throw new CannotDeletePostException();
+		postRepository.delete(post);
+		log.info("[PostDeleteService.delete] post deleted - postId: {}, requestMemberId: {}, requestMemberRole: {}", post.getId(), command.memberId(), command.role());
 	}
 
 	private Post getPost(final Long postId) {

--- a/domain/mathrank-board-domain/src/test/java/kr/co/mathrank/domain/board/service/PostDeleteServiceTest.java
+++ b/domain/mathrank-board-domain/src/test/java/kr/co/mathrank/domain/board/service/PostDeleteServiceTest.java
@@ -14,6 +14,7 @@ import kr.co.mathrank.domain.board.exception.CannotDeletePostException;
 import kr.co.mathrank.domain.board.repository.PostRepository;
 
 @SpringBootTest
+@Transactional
 class PostDeleteServiceTest {
 	@Autowired
 	private PostDeleteService postDeleteService;
@@ -21,7 +22,6 @@ class PostDeleteServiceTest {
 	private PostRepository postRepository;
 
 	@Test
-	@Transactional
 	void 게시글을_찾을_수_없으면_예외발생() {
 		final Long userId = 1L;
 		final Long postId = postRepository.save(Post.ofFree("title", "content", userId))
@@ -33,7 +33,6 @@ class PostDeleteServiceTest {
 	}
 
 	@Test
-	@Transactional
 	void 일반_사용자가_본인_게시글_삭제_가능하다() {
 		final Long userId = 1L;
 		final Long postId = postRepository.save(Post.ofFree("title", "content", userId))
@@ -45,7 +44,6 @@ class PostDeleteServiceTest {
 	}
 
 	@Test
-	@Transactional
 	void 일반_사용자가_본인_게시글외_삭제시_예외발생() {
 		final Long userId = 1L;
 		final Long otherUserId = 2L;

--- a/domain/mathrank-board-domain/src/test/java/kr/co/mathrank/domain/board/service/PostDeleteServiceTest.java
+++ b/domain/mathrank-board-domain/src/test/java/kr/co/mathrank/domain/board/service/PostDeleteServiceTest.java
@@ -24,7 +24,7 @@ class PostDeleteServiceTest {
 	@Transactional
 	void 게시글을_찾을_수_없으면_예외발생() {
 		final Long userId = 1L;
-		final Long postId = postRepository.save(new Post("title", "content", userId))
+		final Long postId = postRepository.save(Post.ofFree("title", "content", userId))
 			.getId();
 		final Long anotherPostId = 1000L;
 
@@ -36,7 +36,7 @@ class PostDeleteServiceTest {
 	@Transactional
 	void 일반_사용자가_본인_게시글_삭제_가능하다() {
 		final Long userId = 1L;
-		final Long postId = postRepository.save(new Post("title", "content", userId))
+		final Long postId = postRepository.save(Post.ofFree("title", "content", userId))
 			.getId();
 
 		postDeleteService.delete(new PostDeleteCommand(postId, userId, Role.USER));
@@ -49,7 +49,7 @@ class PostDeleteServiceTest {
 	void 일반_사용자가_본인_게시글외_삭제시_예외발생() {
 		final Long userId = 1L;
 		final Long otherUserId = 2L;
-		final Long postId = postRepository.save(new Post("title", "content", userId))
+		final Long postId = postRepository.save(Post.ofFree("title", "content", userId))
 			.getId();
 
 		Assertions.assertThrows(CannotDeletePostException.class,
@@ -60,7 +60,7 @@ class PostDeleteServiceTest {
 	void 어드민은_모두_삭제_가능() {
 		final Long userId = 1L;
 		final Long otherUserId = 2L;
-		final Long postId = postRepository.save(new Post("title", "content", userId))
+		final Long postId = postRepository.save(Post.ofFree("title", "content", userId))
 			.getId();
 
 		Assertions.assertDoesNotThrow(

--- a/domain/mathrank-board-domain/src/test/java/kr/co/mathrank/domain/board/service/PostDeleteServiceTest.java
+++ b/domain/mathrank-board-domain/src/test/java/kr/co/mathrank/domain/board/service/PostDeleteServiceTest.java
@@ -1,0 +1,69 @@
+package kr.co.mathrank.domain.board.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.co.mathrank.common.role.Role;
+import kr.co.mathrank.domain.board.dto.PostDeleteCommand;
+import kr.co.mathrank.domain.board.entity.Post;
+import kr.co.mathrank.domain.board.exception.CannotFoundPostException;
+import kr.co.mathrank.domain.board.exception.CannotDeletePostException;
+import kr.co.mathrank.domain.board.repository.PostRepository;
+
+@SpringBootTest
+class PostDeleteServiceTest {
+	@Autowired
+	private PostDeleteService postDeleteService;
+	@Autowired
+	private PostRepository postRepository;
+
+	@Test
+	@Transactional
+	void 게시글을_찾을_수_없으면_예외발생() {
+		final Long userId = 1L;
+		final Long postId = postRepository.save(new Post("title", "content", userId))
+			.getId();
+		final Long anotherPostId = 1000L;
+
+		Assertions.assertThrows(CannotFoundPostException.class,
+			() -> postDeleteService.delete(new PostDeleteCommand(anotherPostId, userId, Role.USER)));
+	}
+
+	@Test
+	@Transactional
+	void 일반_사용자가_본인_게시글_삭제_가능하다() {
+		final Long userId = 1L;
+		final Long postId = postRepository.save(new Post("title", "content", userId))
+			.getId();
+
+		postDeleteService.delete(new PostDeleteCommand(postId, userId, Role.USER));
+
+		Assertions.assertTrue(postRepository.findById(postId).isEmpty());
+	}
+
+	@Test
+	@Transactional
+	void 일반_사용자가_본인_게시글외_삭제시_예외발생() {
+		final Long userId = 1L;
+		final Long otherUserId = 2L;
+		final Long postId = postRepository.save(new Post("title", "content", userId))
+			.getId();
+
+		Assertions.assertThrows(CannotDeletePostException.class,
+			() -> postDeleteService.delete(new PostDeleteCommand(postId, otherUserId, Role.USER)));
+	}
+
+	@Test
+	void 어드민은_모두_삭제_가능() {
+		final Long userId = 1L;
+		final Long otherUserId = 2L;
+		final Long postId = postRepository.save(new Post("title", "content", userId))
+			.getId();
+
+		Assertions.assertDoesNotThrow(
+			() -> postDeleteService.delete(new PostDeleteCommand(postId, otherUserId, Role.ADMIN)));
+	}
+}

--- a/domain/mathrank-board-domain/src/test/java/kr/co/mathrank/domain/board/service/PostDeleteServiceTest.java
+++ b/domain/mathrank-board-domain/src/test/java/kr/co/mathrank/domain/board/service/PostDeleteServiceTest.java
@@ -63,5 +63,6 @@ class PostDeleteServiceTest {
 
 		Assertions.assertDoesNotThrow(
 			() -> postDeleteService.delete(new PostDeleteCommand(postId, otherUserId, Role.ADMIN)));
+		Assertions.assertTrue(postRepository.findById(postId).isEmpty());
 	}
 }


### PR DESCRIPTION
- 어드민만 모든 게시글 삭제 가능
- 일반 사용자는 본인 게시글 삭제 가능

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added post deletion with role-based authorization: owners can delete their own posts; admins can delete any post.
  - Clearer errors when a post is missing or the user lacks permission to delete.

- Tests
  - Added comprehensive tests covering successful deletion, non-existent posts, unauthorized attempts, and admin behavior.

- Chores
  - Updated project dependencies to support role handling and standardized exception management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->