### PR TITLE
feat(board): 게시글 수정 기능 구현

### DIFF
--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/dto/PostUpdateCommand.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/dto/PostUpdateCommand.java
@@ -1,0 +1,17 @@
+package kr.co.mathrank.domain.board.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+public record PostUpdateCommand(
+	@NotNull
+	Long postId,
+	@NotNull
+	Long memberId,
+
+	@NotEmpty
+	String title,
+	@NotEmpty
+	String content
+) {
+}

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/exception/CannotUpdatePostException.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/exception/CannotUpdatePostException.java
@@ -1,0 +1,7 @@
+package kr.co.mathrank.domain.board.exception;
+
+public class CannotUpdatePostException extends PostException {
+	public CannotUpdatePostException() {
+		super(9003, "게시글을 수정할 수 있는 권한 부재");
+	}
+}

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/service/PostUpdateService.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/service/PostUpdateService.java
@@ -1,0 +1,49 @@
+package kr.co.mathrank.domain.board.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.domain.board.dto.PostUpdateCommand;
+import kr.co.mathrank.domain.board.entity.Post;
+import kr.co.mathrank.domain.board.exception.CannotFoundPostException;
+import kr.co.mathrank.domain.board.exception.CannotUpdatePostException;
+import kr.co.mathrank.domain.board.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@Validated
+@RequiredArgsConstructor
+public class PostUpdateService {
+	private final PostRepository postRepository;
+
+	@Transactional
+	public void update(@NotNull @Valid final PostUpdateCommand command) {
+		final Post post = getPost(command.postId());
+		if (!isOwner(command.memberId(), post)) {
+			log.info("[PostUpdateService.update] cannot update post - postId: {}, postOwnerId: {}, requestMemberId: {}", post.getId(), post.getMemberId(), command.memberId());
+			throw new CannotUpdatePostException();
+		}
+		post.setTitle(command.title());
+		post.setContent(command.content());
+		log.info("[PostUpdateService.update] updated post - postId: {}, postOwnerId: {}, requestMemberId: {}", post.getId(), post.getMemberId(), command.memberId());
+	}
+
+	private Post getPost(final Long postId) {
+		return postRepository.findById(postId)
+			.orElseThrow(() -> {
+				log.info("[PostDeleteService.delete] cannot found post - postId: {}", postId);
+				return new CannotFoundPostException();
+			});
+	}
+
+	private boolean isOwner(final Long requestMemberId, final Post post) {
+		// 일반 사용자일 경우 본인 글만 지울 수 있음
+		// 주인장도 수정은 불가!
+		return requestMemberId.equals(post.getMemberId());
+	}
+}

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/service/PostUpdateService.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/service/PostUpdateService.java
@@ -36,7 +36,7 @@ public class PostUpdateService {
 	private Post getPost(final Long postId) {
 		return postRepository.findById(postId)
 			.orElseThrow(() -> {
-				log.info("[PostDeleteService.delete] cannot found post - postId: {}", postId);
+				log.info("[PostUpdateService.update] cannot found post - postId: {}", postId);
 				return new CannotFoundPostException();
 			});
 	}

--- a/domain/mathrank-board-domain/src/test/java/kr/co/mathrank/domain/board/service/PostUpdateServiceTest.java
+++ b/domain/mathrank-board-domain/src/test/java/kr/co/mathrank/domain/board/service/PostUpdateServiceTest.java
@@ -1,0 +1,56 @@
+package kr.co.mathrank.domain.board.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.co.mathrank.domain.board.dto.PostUpdateCommand;
+import kr.co.mathrank.domain.board.entity.Post;
+import kr.co.mathrank.domain.board.exception.CannotUpdatePostException;
+import kr.co.mathrank.domain.board.repository.PostRepository;
+
+@SpringBootTest
+@Transactional
+class PostUpdateServiceTest {
+	@Autowired
+	private PostRepository postRepository;
+	@Autowired
+	private PostUpdateService postUpdateService;
+
+	@Test
+	void 본인이_수정할땐_성공() {
+		final Long userId = 1L;
+		final Long postId = postRepository.save(Post.ofFree("title", "content", userId))
+			.getId();
+
+		postUpdateService.update(new PostUpdateCommand(postId, userId, "newTitle", "newContent"));
+
+		final Post post = postRepository.findById(postId).get();
+
+		Assertions.assertAll(
+			() -> Assertions.assertEquals("newTitle", post.getTitle()),
+			() -> Assertions.assertEquals("newContent", post.getContent())
+		);
+	}
+
+	@Test
+	void 어드민이든_뭐든_본인게_아니면_수정_불가() {
+		final Long userId = 1L;
+		final Long anotherUserId = 2L;
+		final Long postId = postRepository.save(Post.ofFree("title", "content", userId))
+			.getId();
+
+		postUpdateService.update(new PostUpdateCommand(postId, userId, "newTitle", "newContent"));
+
+		Assertions.assertAll(
+			() -> Assertions.assertThrows(CannotUpdatePostException.class, () -> postUpdateService.update(
+				new PostUpdateCommand(postId, anotherUserId, "newTitle", "newContent")
+			))
+		);
+
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Users can update their own posts (title and content) with validation.
- Bug Fixes
  - Enforced ownership checks: non-owners (including admins) cannot update others’ posts.
  - Clear error shown when lacking permission.
  - Validation prevents empty titles/content and missing identifiers.
- Tests
  - Added integration tests covering successful owner updates and blocked non-owner attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->