### PR TITLE
feat(board): notice 타입 게시글 추가

### DIFF
--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/constraints/NoticePostConstraint.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/constraints/NoticePostConstraint.java
@@ -1,0 +1,18 @@
+package kr.co.mathrank.domain.board.constraints;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = NoticePostConstraintValidator.class)
+public @interface NoticePostConstraint {
+	String message() default "공지사항은 관리자만 작성 가능합니다.";
+	Class<?>[] groups() default {};
+	Class<? extends Payload>[] payload() default {};
+}

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/constraints/NoticePostConstraintValidator.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/constraints/NoticePostConstraintValidator.java
@@ -1,0 +1,16 @@
+package kr.co.mathrank.domain.board.constraints;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import kr.co.mathrank.common.role.Role;
+
+class NoticePostConstraintValidator implements ConstraintValidator<NoticePostConstraint, Role> {
+	@Override
+	public boolean isValid(Role role, ConstraintValidatorContext constraintValidatorContext) {
+		if (role == null) {
+			return false;
+		}
+
+		return role == Role.ADMIN;
+	}
+}

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/constraints/PostGroupSequenceProvider.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/constraints/PostGroupSequenceProvider.java
@@ -23,6 +23,7 @@ public class PostGroupSequenceProvider implements DefaultGroupSequenceProvider<P
 			case ASSESSMENT -> groups.add(ValidationGroups.AssessmentPostGroup.class);
 			case CONTEST -> groups.add(ValidationGroups.ContestPostGroup.class);
 			case FREE -> groups.add(ValidationGroups.FreePostGroup.class);
+			case NOTICE -> groups.add(ValidationGroups.NoticePostGroup.class);
 		}
 		return groups;
 	}

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/constraints/ValidationGroups.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/constraints/ValidationGroups.java
@@ -7,4 +7,5 @@ public class ValidationGroups {
 	public interface AssessmentPostGroup extends Default {}
 	public interface ContestPostGroup extends Default {}
 	public interface FreePostGroup extends Default {}
+	public interface NoticePostGroup extends Default {}
 }

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/dto/PostRegisterCommand.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/dto/PostRegisterCommand.java
@@ -34,11 +34,39 @@ public record PostRegisterCommand(
 ) {
 	public Post toEntity() {
 		return switch (postType) {
-			case FREE -> Post.ofFree(title, content, memberId);
-			case CONTEST -> Post.ofContest(title, content, memberId, contestId);
-			case ASSESSMENT -> Post.ofAssessment(title, content, memberId, assessmentId);
-			case SINGLE_PROBLEM -> Post.ofSingleProblem(title, content, memberId, problemId);
-			case NOTICE -> Post.ofNotice(title, content, memberId);
+			case FREE -> Post.builder()
+				.title(title)
+				.content(content)
+				.memberId(memberId)
+				.postType(PostType.FREE)
+				.build();
+			case CONTEST -> Post.builder()
+				.title(title)
+				.content(content)
+				.memberId(memberId)
+				.contestId(contestId)
+				.postType(PostType.CONTEST)
+				.build();
+			case ASSESSMENT -> Post.builder()
+				.title(title)
+				.content(content)
+				.memberId(memberId)
+				.assessmentId(assessmentId)
+				.postType(PostType.ASSESSMENT)
+				.build();
+			case SINGLE_PROBLEM -> Post.builder()
+				.title(title)
+				.content(content)
+				.memberId(memberId)
+				.postType(PostType.SINGLE_PROBLEM)
+				.singleProblemId(problemId)
+				.build();
+			case NOTICE -> Post.builder()
+				.title(title)
+				.content(content)
+				.memberId(memberId)
+				.postType(PostType.NOTICE)
+				.build();
 		};
 	}
 }

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/dto/PostRegisterCommand.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/dto/PostRegisterCommand.java
@@ -36,24 +36,19 @@ public record PostRegisterCommand(
 		final Post.PostBuilder postBuilder = Post.builder()
 			.title(title)
 			.content(content)
-			.memberId(memberId);
+			.memberId(memberId)
+			.postType(postType);
 
-		final Post.PostBuilder post = switch (postType) {
-			case FREE -> postBuilder
-				.postType(PostType.FREE);
+		switch (postType) {
 			case CONTEST -> postBuilder
-				.contestId(contestId)
-				.postType(PostType.CONTEST);
+				.contestId(contestId);
 			case ASSESSMENT -> postBuilder
-				.assessmentId(assessmentId)
-				.postType(PostType.ASSESSMENT);
+				.assessmentId(assessmentId);
 			case SINGLE_PROBLEM -> postBuilder
-				.postType(PostType.SINGLE_PROBLEM)
 				.singleProblemId(problemId);
-			case NOTICE -> postBuilder
-				.postType(PostType.NOTICE);
+			case NOTICE, FREE -> {}
 		};
 
-		return post.build();
+		return postBuilder.build();
 	}
 }

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/dto/PostRegisterCommand.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/dto/PostRegisterCommand.java
@@ -33,40 +33,27 @@ public record PostRegisterCommand(
 	Long contestId
 ) {
 	public Post toEntity() {
-		return switch (postType) {
-			case FREE -> Post.builder()
-				.title(title)
-				.content(content)
-				.memberId(memberId)
-				.postType(PostType.FREE)
-				.build();
-			case CONTEST -> Post.builder()
-				.title(title)
-				.content(content)
-				.memberId(memberId)
+		final Post.PostBuilder postBuilder = Post.builder()
+			.title(title)
+			.content(content)
+			.memberId(memberId);
+
+		final Post.PostBuilder post = switch (postType) {
+			case FREE -> postBuilder
+				.postType(PostType.FREE);
+			case CONTEST -> postBuilder
 				.contestId(contestId)
-				.postType(PostType.CONTEST)
-				.build();
-			case ASSESSMENT -> Post.builder()
-				.title(title)
-				.content(content)
-				.memberId(memberId)
+				.postType(PostType.CONTEST);
+			case ASSESSMENT -> postBuilder
 				.assessmentId(assessmentId)
-				.postType(PostType.ASSESSMENT)
-				.build();
-			case SINGLE_PROBLEM -> Post.builder()
-				.title(title)
-				.content(content)
-				.memberId(memberId)
+				.postType(PostType.ASSESSMENT);
+			case SINGLE_PROBLEM -> postBuilder
 				.postType(PostType.SINGLE_PROBLEM)
-				.singleProblemId(problemId)
-				.build();
-			case NOTICE -> Post.builder()
-				.title(title)
-				.content(content)
-				.memberId(memberId)
-				.postType(PostType.NOTICE)
-				.build();
+				.singleProblemId(problemId);
+			case NOTICE -> postBuilder
+				.postType(PostType.NOTICE);
 		};
+
+		return post.build();
 	}
 }

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/dto/PostRegisterCommand.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/dto/PostRegisterCommand.java
@@ -4,6 +4,8 @@ import org.hibernate.validator.group.GroupSequenceProvider;
 
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.common.role.Role;
+import kr.co.mathrank.domain.board.constraints.NoticePostConstraint;
 import kr.co.mathrank.domain.board.constraints.PostGroupSequenceProvider;
 import kr.co.mathrank.domain.board.constraints.ValidationGroups;
 import kr.co.mathrank.domain.board.entity.Post;
@@ -20,6 +22,9 @@ public record PostRegisterCommand(
 	@NotNull
 	Long memberId,
 
+	@NoticePostConstraint(groups = ValidationGroups.NoticePostGroup.class)
+	Role memberRole,
+
 	@NotNull(groups = ValidationGroups.SingleProblemPostGroup.class)
 	Long problemId,
 	@NotNull(groups = ValidationGroups.AssessmentPostGroup.class)
@@ -33,6 +38,7 @@ public record PostRegisterCommand(
 			case CONTEST -> Post.ofContest(title, content, memberId, contestId);
 			case ASSESSMENT -> Post.ofAssessment(title, content, memberId, assessmentId);
 			case SINGLE_PROBLEM -> Post.ofSingleProblem(title, content, memberId, problemId);
+			case NOTICE -> Post.ofNotice(title, content, memberId);
 		};
 	}
 }

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/entity/Post.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/entity/Post.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -43,47 +44,27 @@ public class Post {
 	@CreationTimestamp
 	private LocalDateTime createdAt;
 
+	@Builder
+	Post(String title, String content, Long memberId, PostType postType, Long contestId, Long assessmentId,
+		Long singleProblemId) {
+		this.title = title;
+		this.content = content;
+		this.memberId = memberId;
+
+		this.postType = postType;
+
+		this.contestId = contestId;
+		this.assessmentId = assessmentId;
+		this.singleProblemId = singleProblemId;
+	}
+
 	private Post(String title, String content, Long userId) {
 		this.title = title;
 		this.content = content;
 		this.memberId = userId;
 	}
 
-	public static Post ofFree(String title, String content, Long userId) {
-		final Post post = new Post(title, content, userId);
-		post.postType = PostType.FREE;
-
-		return post;
-	}
-
-	public static Post ofContest(String title, String content, Long userId, Long contestId) {
-		final Post post = new Post(title, content, userId);
-		post.contestId = contestId;
-		post.postType = PostType.CONTEST;
-
-		return post;
-	}
-
-	public static Post ofAssessment(String title, String content, Long userId, Long assessmentId) {
-		final Post post = new Post(title, content, userId);
-		post.assessmentId = assessmentId;
-		post.postType = PostType.ASSESSMENT;
-
-		return post;
-	}
-
-	public static Post ofSingleProblem(String title, String content, Long userId, Long singelProblemId) {
-		final Post post = new Post(title, content, userId);
-		post.singleProblemId = singelProblemId;
-		post.postType = PostType.SINGLE_PROBLEM;
-
-		return post;
-	}
-
-	public static Post ofNotice(String title, String content, Long userId) {
-		final Post post = new Post(title, content, userId);
-		post.postType = PostType.NOTICE;
-
-		return post;
+	public static Post of(String title, String content, Long userId) {
+		return new Post(title, content, userId);
 	}
 }

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/entity/Post.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/entity/Post.java
@@ -79,4 +79,11 @@ public class Post {
 
 		return post;
 	}
+
+	public static Post ofNotice(String title, String content, Long userId) {
+		final Post post = new Post(title, content, userId);
+		post.postType = PostType.NOTICE;
+
+		return post;
+	}
 }

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/entity/PostType.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/entity/PostType.java
@@ -4,5 +4,6 @@ public enum PostType {
 	FREE,
 	CONTEST,
 	ASSESSMENT,
-	SINGLE_PROBLEM
+	SINGLE_PROBLEM,
+	NOTICE
 }

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/service/PostRegisterService.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/service/PostRegisterService.java
@@ -21,7 +21,7 @@ public class PostRegisterService {
 	public Long register(@NotNull @Valid final PostRegisterCommand command) {
 		final Post post = command.toEntity();
 		postRepository.save(post);
-		log.info("[PostRegisterService.register] post saved - postId: {}", post.getId());
+		log.info("[PostRegisterService.register] post saved - postId: {}, postType: {}", post.getId(), post.getPostType());
 		return post.getId();
 	}
 }

--- a/domain/mathrank-board-domain/src/test/java/kr/co/mathrank/domain/board/service/PostDeleteServiceTest.java
+++ b/domain/mathrank-board-domain/src/test/java/kr/co/mathrank/domain/board/service/PostDeleteServiceTest.java
@@ -24,7 +24,7 @@ class PostDeleteServiceTest {
 	@Test
 	void 게시글을_찾을_수_없으면_예외발생() {
 		final Long userId = 1L;
-		final Long postId = postRepository.save(Post.ofFree("title", "content", userId))
+		final Long postId = postRepository.save(Post.of("title", "content", userId))
 			.getId();
 		final Long anotherPostId = 1000L;
 
@@ -35,7 +35,7 @@ class PostDeleteServiceTest {
 	@Test
 	void 일반_사용자가_본인_게시글_삭제_가능하다() {
 		final Long userId = 1L;
-		final Long postId = postRepository.save(Post.ofFree("title", "content", userId))
+		final Long postId = postRepository.save(Post.of("title", "content", userId))
 			.getId();
 
 		postDeleteService.delete(new PostDeleteCommand(postId, userId, Role.USER));
@@ -47,7 +47,7 @@ class PostDeleteServiceTest {
 	void 일반_사용자가_본인_게시글외_삭제시_예외발생() {
 		final Long userId = 1L;
 		final Long otherUserId = 2L;
-		final Long postId = postRepository.save(Post.ofFree("title", "content", userId))
+		final Long postId = postRepository.save(Post.of("title", "content", userId))
 			.getId();
 
 		Assertions.assertThrows(CannotDeletePostException.class,
@@ -58,7 +58,7 @@ class PostDeleteServiceTest {
 	void 어드민은_모두_삭제_가능() {
 		final Long userId = 1L;
 		final Long otherUserId = 2L;
-		final Long postId = postRepository.save(Post.ofFree("title", "content", userId))
+		final Long postId = postRepository.save(Post.of("title", "content", userId))
 			.getId();
 
 		Assertions.assertDoesNotThrow(

--- a/domain/mathrank-board-domain/src/test/java/kr/co/mathrank/domain/board/service/PostRegisterServiceTest.java
+++ b/domain/mathrank-board-domain/src/test/java/kr/co/mathrank/domain/board/service/PostRegisterServiceTest.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import jakarta.validation.ConstraintViolationException;
+import kr.co.mathrank.common.role.Role;
 import kr.co.mathrank.domain.board.dto.PostRegisterCommand;
 import kr.co.mathrank.domain.board.entity.PostType;
 
@@ -19,34 +20,44 @@ class PostRegisterServiceTest {
 		Assertions.assertAll(
 			// 본문이 empty, 타입 지정
 			() -> Assertions.assertThrows(ConstraintViolationException.class, () -> postRegisterService.register(
-				new PostRegisterCommand(PostType.CONTEST, "title", "", 1L, 1L, 1L, 1L))),
+				new PostRegisterCommand(PostType.CONTEST, "title", "", 1L, Role.ADMIN, 1L, 1L, 1L))),
 			// 본문이 empty, 타입 지정 안됨
 			() -> Assertions.assertThrows(ConstraintViolationException.class, () -> postRegisterService.register(
-				new PostRegisterCommand(null, "title", "", 1L, 1L, 1L, 1L)))
+				new PostRegisterCommand(null, "title", "", 1L, Role.ADMIN, 1L, 1L, 1L)))
 		);
 	}
 
 	@Test
 	void 게시글_타입이_지정안되면_예외() {
 		Assertions.assertThrows(ConstraintViolationException.class, () -> postRegisterService.register(
-			new PostRegisterCommand(null, "title", "content", 1L, 1L, 1L, 1L)));
+			new PostRegisterCommand(null, "title", "content", 1L, Role.ADMIN, 1L, 1L, 1L)));
 	}
 
 	@Test
 	void 개별문제_게시글_동적_검증_테스트() {
 		Assertions.assertThrows(ConstraintViolationException.class, () -> postRegisterService.register(
-			new PostRegisterCommand(PostType.SINGLE_PROBLEM, "title", "content", 1L, null, 1L, 1L)));
+			new PostRegisterCommand(PostType.SINGLE_PROBLEM, "title", "content", 1L, Role.ADMIN, null, 1L, 1L)));
 	}
 
 	@Test
 	void 문제집_게시글_동적_검증_테스트() {
 		Assertions.assertThrows(ConstraintViolationException.class, () -> postRegisterService.register(
-			new PostRegisterCommand(PostType.ASSESSMENT, "title", "content", 1L, 1L, null, 1L)));
+			new PostRegisterCommand(PostType.ASSESSMENT, "title", "content", 1L, Role.ADMIN, 1L, null, 1L)));
 	}
 
 	@Test
 	void 대회_게시글_동적_검증_테스트() {
 		Assertions.assertThrows(ConstraintViolationException.class, () -> postRegisterService.register(
-			new PostRegisterCommand(PostType.CONTEST, "title", "content", 1L, 1L, 1L, null)));
+			new PostRegisterCommand(PostType.CONTEST, "title", "content", 1L, Role.ADMIN, 1L, 1L, null)));
+	}
+
+	@Test
+	void 공지사항_게시글은_관리자만_작성가능하다() {
+		Assertions.assertAll(
+			() -> Assertions.assertThrows(ConstraintViolationException.class, () -> postRegisterService.register(
+				new PostRegisterCommand(PostType.NOTICE, "title", "content", 1L, Role.USER, 1L, 1L, null))),
+			() -> Assertions.assertDoesNotThrow(() -> postRegisterService.register(
+				new PostRegisterCommand(PostType.NOTICE, "title", "content", 1L, Role.ADMIN, 1L, 1L, null)))
+		);
 	}
 }

--- a/domain/mathrank-board-domain/src/test/java/kr/co/mathrank/domain/board/service/PostUpdateServiceTest.java
+++ b/domain/mathrank-board-domain/src/test/java/kr/co/mathrank/domain/board/service/PostUpdateServiceTest.java
@@ -1,7 +1,5 @@
 package kr.co.mathrank.domain.board.service;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,7 +22,7 @@ class PostUpdateServiceTest {
 	@Test
 	void 본인이_수정할땐_성공() {
 		final Long userId = 1L;
-		final Long postId = postRepository.save(Post.ofFree("title", "content", userId))
+		final Long postId = postRepository.save(Post.of("title", "content", userId))
 			.getId();
 
 		postUpdateService.update(new PostUpdateCommand(postId, userId, "newTitle", "newContent"));
@@ -41,7 +39,7 @@ class PostUpdateServiceTest {
 	void 어드민이든_뭐든_본인게_아니면_수정_불가() {
 		final Long userId = 1L;
 		final Long anotherUserId = 2L;
-		final Long postId = postRepository.save(Post.ofFree("title", "content", userId))
+		final Long postId = postRepository.save(Post.of("title", "content", userId))
 			.getId();
 
 		postUpdateService.update(new PostUpdateCommand(postId, userId, "newTitle", "newContent"));


### PR DESCRIPTION
- 엔티티 생성 방식 빌더패턴으로 수정 
- `Notice` 타입 게시글 작성은 괸리자만 가능하도록 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new "Notice" post type and enforced that only administrators can create Notice posts (clear validation message on violation).
  - Post creation flows now handle all post types consistently.

- **Behavior**
  - Post registration logs now include both post ID and post type for clearer auditability.

- **Tests**
  - Expanded tests to cover admin-only Notice creation and updated scenarios for the role requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->