### PR TITLE
feat(board): 페이징 조회에 사용자 Id, 닉네임, 문제Id 조건 추가 

### DIFF
--- a/domain/mathrank-board-domain/build.gradle
+++ b/domain/mathrank-board-domain/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     implementation project(':common:mathrank-exception')
     implementation project(':common:mathrank-querydsl')
     implementation project(':common:mathrank-page')
+    implementation project(':client:internal:mathrank-member-client')
 
     testRuntimeOnly 'com.h2database:h2'
 

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/dto/PostPageQuery.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/dto/PostPageQuery.java
@@ -3,6 +3,7 @@ package kr.co.mathrank.domain.board.dto;
 public record PostPageQuery(
 	Long postId,
 	Long memberId,
+	String nickName,
 
 	String title,
 

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/dto/PostRegisterCommand.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/dto/PostRegisterCommand.java
@@ -32,11 +32,12 @@ public record PostRegisterCommand(
 	@NotNull(groups = ValidationGroups.ContestPostGroup.class)
 	Long contestId
 ) {
-	public Post toEntity() {
+	public Post toEntity(String memberName) {
 		final Post.PostBuilder postBuilder = Post.builder()
 			.title(title)
 			.content(content)
 			.memberId(memberId)
+			.memberNickName(memberName)
 			.postType(postType);
 
 		switch (postType) {

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/entity/Post.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/entity/Post.java
@@ -69,9 +69,6 @@ public class Post {
 		this.singleProblemId = singleProblemId;
 	}
 
-	@Builder
-
-
 	private Post(String title, String content, Long userId) {
 		this.title = title;
 		this.content = content;

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/entity/Post.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/entity/Post.java
@@ -25,6 +25,7 @@ import lombok.Setter;
 	@Index(name = "idx_createdAt_contestId", columnList = "created_at, contest_id"),
 	@Index(name = "idx_createdAt_assessmentId", columnList = "created_at, assessment_id"),
 	@Index(name = "idx_createdAt_singleProblemId", columnList = "created_at, single_problem_id"),
+	@Index(name = "idx_createdAt_nickName", columnList = "created_at, member_nick_name")
 })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post {

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/entity/Post.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/entity/Post.java
@@ -40,6 +40,8 @@ public class Post {
 
 	private Long memberId;
 
+	private String memberNickName;
+
 	@Enumerated(EnumType.STRING)
 	private PostType postType;
 
@@ -53,18 +55,20 @@ public class Post {
 	private LocalDateTime createdAt;
 
 	@Builder
-	Post(String title, String content, Long memberId, PostType postType, Long contestId, Long assessmentId,
-		Long singleProblemId) {
+	public Post(String title, String content, Long memberId, String memberNickName, PostType postType, Long contestId,
+		Long assessmentId, Long singleProblemId) {
 		this.title = title;
 		this.content = content;
 		this.memberId = memberId;
-
+		this.memberNickName = memberNickName;
 		this.postType = postType;
-
 		this.contestId = contestId;
 		this.assessmentId = assessmentId;
 		this.singleProblemId = singleProblemId;
 	}
+
+	@Builder
+
 
 	private Post(String title, String content, Long userId) {
 		this.title = title;

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/entity/Post.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/entity/Post.java
@@ -25,7 +25,8 @@ import lombok.Setter;
 	@Index(name = "idx_createdAt_contestId", columnList = "created_at, contest_id"),
 	@Index(name = "idx_createdAt_assessmentId", columnList = "created_at, assessment_id"),
 	@Index(name = "idx_createdAt_singleProblemId", columnList = "created_at, single_problem_id"),
-	@Index(name = "idx_createdAt_nickName", columnList = "created_at, member_nick_name")
+	@Index(name = "idx_createdAt_nickName", columnList = "created_at, member_nick_name"),
+	@Index(name = "idx_createdAt_memberId", columnList = "created_at, member_id")
 })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post {

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/entity/Post.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/entity/Post.java
@@ -21,12 +21,12 @@ import lombok.Setter;
 @Entity
 @Getter
 @Table(indexes = {
-	@Index(name = "idx_createdAt_title", columnList = "created_at, title"),
-	@Index(name = "idx_createdAt_contestId", columnList = "created_at, contest_id"),
-	@Index(name = "idx_createdAt_assessmentId", columnList = "created_at, assessment_id"),
-	@Index(name = "idx_createdAt_singleProblemId", columnList = "created_at, single_problem_id"),
-	@Index(name = "idx_createdAt_nickName", columnList = "created_at, member_nick_name"),
-	@Index(name = "idx_createdAt_memberId", columnList = "created_at, member_id")
+	@Index(name = "idx_createdAt_title", columnList = "created_at desc, title"),
+	@Index(name = "idx_createdAt_contestId", columnList = "created_at desc, contest_id"),
+	@Index(name = "idx_createdAt_assessmentId", columnList = "created_at desc, assessment_id"),
+	@Index(name = "idx_createdAt_singleProblemId", columnList = "created_at desc, single_problem_id"),
+	@Index(name = "idx_createdAt_nickName", columnList = "created_at desc, member_nick_name"),
+	@Index(name = "idx_createdAt_memberId", columnList = "created_at desc, member_id")
 })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post {

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/entity/Post.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/entity/Post.java
@@ -21,12 +21,12 @@ import lombok.Setter;
 @Entity
 @Getter
 @Table(indexes = {
-	@Index(name = "idx_createdAt_title", columnList = "created_at desc, title"),
-	@Index(name = "idx_createdAt_contestId", columnList = "created_at desc, contest_id"),
-	@Index(name = "idx_createdAt_assessmentId", columnList = "created_at desc, assessment_id"),
-	@Index(name = "idx_createdAt_singleProblemId", columnList = "created_at desc, single_problem_id"),
-	@Index(name = "idx_createdAt_nickName", columnList = "created_at desc, member_nick_name"),
-	@Index(name = "idx_createdAt_memberId", columnList = "created_at desc, member_id")
+	@Index(name = "idx_title_createdAt", columnList = "title, created_at desc"),
+	@Index(name = "idx_contestId_createdAt", columnList = "contest_id, created_at desc"),
+	@Index(name = "idx_assessmentId_createdAt", columnList = "assessment_id, created_at desc"),
+	@Index(name = "idx_singleProblemId_createdAt", columnList = "single_problem_id, created_at desc"),
+	@Index(name = "idx_nickName_createdAt", columnList = "member_nick_name, created_at desc"),
+	@Index(name = "idx_memberId_createdAt", columnList = "member_id, created_at desc")
 })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post {

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/entity/Post.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/entity/Post.java
@@ -26,7 +26,9 @@ import lombok.Setter;
 	@Index(name = "idx_assessmentId_createdAt", columnList = "assessment_id, created_at desc"),
 	@Index(name = "idx_singleProblemId_createdAt", columnList = "single_problem_id, created_at desc"),
 	@Index(name = "idx_nickName_createdAt", columnList = "member_nick_name, created_at desc"),
-	@Index(name = "idx_memberId_createdAt", columnList = "member_id, created_at desc")
+	@Index(name = "idx_memberId_createdAt", columnList = "member_id, created_at desc"),
+	@Index(name = "idx_postType_createdAt", columnList = "post_type, created_at desc"),
+	@Index(name = "idx_createdAt", columnList = "created_at desc"),
 })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post {

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/entity/Post.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/entity/Post.java
@@ -21,11 +21,9 @@ import lombok.Setter;
 @Entity
 @Getter
 @Table(indexes = {
-	@Index(name = "idx_title_createdAt", columnList = "title, created_at desc"),
 	@Index(name = "idx_contestId_createdAt", columnList = "contest_id, created_at desc"),
 	@Index(name = "idx_assessmentId_createdAt", columnList = "assessment_id, created_at desc"),
 	@Index(name = "idx_singleProblemId_createdAt", columnList = "single_problem_id, created_at desc"),
-	@Index(name = "idx_nickName_createdAt", columnList = "member_nick_name, created_at desc"),
 	@Index(name = "idx_memberId_createdAt", columnList = "member_id, created_at desc"),
 	@Index(name = "idx_postType_createdAt", columnList = "post_type, created_at desc"),
 	@Index(name = "idx_createdAt", columnList = "created_at desc"),

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/repository/PostQueryRepositoryImpl.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/repository/PostQueryRepositoryImpl.java
@@ -55,8 +55,17 @@ class PostQueryRepositoryImpl implements PostQueryRepository {
 			matchContestId(postQuery.contestId()),
 			containsTitle(postQuery.title()),
 			containsMemberNickName(postQuery.nickName()),
-			matchMemberId(postQuery.memberId())
+			matchMemberId(postQuery.memberId()),
+			matchSingleProblemId(postQuery.singleProblemId())
 		};
+	}
+
+	private BooleanExpression matchSingleProblemId(final Long singleProblemId) {
+		if (singleProblemId == null) {
+			return null;
+		}
+
+		return QPost.post.singleProblemId.eq(singleProblemId);
 	}
 
 	private BooleanExpression matchMemberId(final Long memberId) {

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/repository/PostQueryRepositoryImpl.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/repository/PostQueryRepositoryImpl.java
@@ -53,7 +53,8 @@ class PostQueryRepositoryImpl implements PostQueryRepository {
 			matchPostId(postQuery.postId()),
 			matchAssessmentId(postQuery.assessmentId()),
 			matchContestId(postQuery.contestId()),
-			containsTitle(postQuery.title())
+			containsTitle(postQuery.title()),
+			containsMemberNickName(postQuery.nickName())
 		};
 	}
 
@@ -63,6 +64,14 @@ class PostQueryRepositoryImpl implements PostQueryRepository {
 		}
 
 		return QPost.post.id.eq(postId);
+	}
+
+	private BooleanExpression containsMemberNickName(final String nickName) {
+		if (nickName == null) {
+			return null;
+		}
+
+		return QPost.post.memberNickName.contains(nickName);
 	}
 
 	private BooleanExpression matchAssessmentId(final Long assessmentId) {

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/repository/PostQueryRepositoryImpl.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/repository/PostQueryRepositoryImpl.java
@@ -54,8 +54,17 @@ class PostQueryRepositoryImpl implements PostQueryRepository {
 			matchAssessmentId(postQuery.assessmentId()),
 			matchContestId(postQuery.contestId()),
 			containsTitle(postQuery.title()),
-			containsMemberNickName(postQuery.nickName())
+			containsMemberNickName(postQuery.nickName()),
+			matchMemberId(postQuery.memberId())
 		};
+	}
+
+	private BooleanExpression matchMemberId(final Long memberId) {
+		if (memberId == null) {
+			return null;
+		}
+
+		return QPost.post.memberId.eq(memberId);
 	}
 
 	private BooleanExpression matchPostId(final Long postId) {

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/service/PostMemberManager.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/service/PostMemberManager.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 class PostMemberManager {
-	private MemberClient memberClient;
+	private final MemberClient memberClient;
 
 	public String fetchMemberNickName(@NotNull final Long memberId) {
 		return memberClient.getMemberInfo(memberId)

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/service/PostMemberManager.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/service/PostMemberManager.java
@@ -1,12 +1,14 @@
 package kr.co.mathrank.domain.board.service;
 
 import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
 
 import jakarta.validation.constraints.NotNull;
 import kr.co.mathrank.client.internal.member.MemberClient;
 import lombok.RequiredArgsConstructor;
 
 @Component
+@Validated
 @RequiredArgsConstructor
 class PostMemberManager {
 	private final MemberClient memberClient;

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/service/PostMemberManager.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/service/PostMemberManager.java
@@ -1,0 +1,18 @@
+package kr.co.mathrank.domain.board.service;
+
+import org.springframework.stereotype.Component;
+
+import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.client.internal.member.MemberClient;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+class PostMemberManager {
+	private MemberClient memberClient;
+
+	public String fetchMemberNickName(@NotNull final Long memberId) {
+		return memberClient.getMemberInfo(memberId)
+			.memberName();
+	}
+}

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/service/PostRegisterService.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/service/PostRegisterService.java
@@ -17,9 +17,11 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class PostRegisterService {
 	private final PostRepository postRepository;
+	private final PostMemberManager postMemberManager;
 
 	public Long register(@NotNull @Valid final PostRegisterCommand command) {
-		final Post post = command.toEntity();
+		final String nickName = postMemberManager.fetchMemberNickName(command.memberId());
+		final Post post = command.toEntity(nickName);
 		postRepository.save(post);
 		log.info("[PostRegisterService.register] post saved - postId: {}, postType: {}", post.getId(), post.getPostType());
 		return post.getId();

--- a/domain/mathrank-board-domain/src/test/java/kr/co/mathrank/domain/board/service/PostRegisterServiceTest.java
+++ b/domain/mathrank-board-domain/src/test/java/kr/co/mathrank/domain/board/service/PostRegisterServiceTest.java
@@ -4,8 +4,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import jakarta.validation.ConstraintViolationException;
+import kr.co.mathrank.client.internal.member.MemberClient;
 import kr.co.mathrank.common.role.Role;
 import kr.co.mathrank.domain.board.dto.PostRegisterCommand;
 import kr.co.mathrank.domain.board.entity.PostType;
@@ -14,6 +16,8 @@ import kr.co.mathrank.domain.board.entity.PostType;
 class PostRegisterServiceTest {
 	@Autowired
 	private PostRegisterService postRegisterService;
+	@MockitoBean
+	private PostMemberManager postMemberManager;
 
 	@Test
 	void 타입에_상관없이_디폴트_예외처리() {

--- a/domain/mathrank-board-domain/src/test/resources/application.properties
+++ b/domain/mathrank-board-domain/src/test/resources/application.properties
@@ -1,0 +1,5 @@
+client.member.read-timeout-seconds=10
+client.member.host=http://localhost
+client.member.connection-timeout-seconds=10
+client.member.port=8080
+client.member.uri=/api/inner/v1/member/info


### PR DESCRIPTION
- 인덱스 적용 
- 닉네임 저장을 위해 동기적으로 호출하도록 구성
  - 비동기 호출로 백그라운드 처리할 순 있지만, 현재 서비스 규모에서 오버엔지니어링 필요 있는지 의문 
  - 만약 한다면, `Post`에 `Status`필드 추가, 이미 저장된 `memberId`로 클라이언트 비동기  호출, 존재하면 SUCCESS or 실패하면 PENDING으로 다시 status 변경
- 닉네임, 제목 이용 검색 시, full table scan 이 발생하게 됨
  - 아래 대안 고려
  - mysql full text index
  - open search

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Posts now store the author’s nickname on creation.
  - Board listing/search can be filtered by author nickname and by member ID.
  - Service resolves member nicknames when registering posts.

- Performance Improvements
  - Added several indexes to speed up board listing and author-related queries.

- Chores
  - Added member-client dependency and test config for member info retrieval.

- Tests
  - Test wiring updated to mock the nickname-resolving component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->