### PR TITLE
feat(problem): 기출문제 여부 추가

### DIFF
--- a/app/api/mathrank-problem-api/src/main/java/kr/co/mathrank/app/api/problem/Requests.java
+++ b/app/api/mathrank-problem-api/src/main/java/kr/co/mathrank/app/api/problem/Requests.java
@@ -2,6 +2,7 @@ package kr.co.mathrank.app.api.problem;
 
 import java.util.Set;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -23,6 +24,7 @@ class Requests {
 		String coursePath,
 		@NotNull
 		Difficulty difficulty,
+		@NotNull
 		PastProblem pastProblem,
 		String schoolCode,
 		@Size(min = 1, max = 100)
@@ -60,6 +62,7 @@ class Requests {
 		String coursePath,
 		@NotNull
 		Difficulty difficulty,
+		@NotNull
 		PastProblem pastProblem,
 		String schoolCode,
 		@Size(min = 1, max = 100)

--- a/app/api/mathrank-problem-api/src/main/java/kr/co/mathrank/app/api/problem/Requests.java
+++ b/app/api/mathrank-problem-api/src/main/java/kr/co/mathrank/app/api/problem/Requests.java
@@ -60,6 +60,7 @@ class Requests {
 		String coursePath,
 		@NotNull
 		Difficulty difficulty,
+		PastProblem pastProblem,
 		String schoolCode,
 		@Size(min = 1, max = 100)
 		Set<String> answers,
@@ -75,6 +76,7 @@ class Requests {
 				solutionImage,
 				answerType,
 				difficulty,
+				pastProblem,
 				coursePath,
 				schoolCode,
 				answers,

--- a/app/api/mathrank-problem-api/src/main/java/kr/co/mathrank/app/api/problem/Requests.java
+++ b/app/api/mathrank-problem-api/src/main/java/kr/co/mathrank/app/api/problem/Requests.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 import kr.co.mathrank.domain.problem.dto.ProblemRegisterCommand;
 import kr.co.mathrank.domain.problem.dto.ProblemUpdateCommand;
 
@@ -22,6 +23,7 @@ class Requests {
 		String coursePath,
 		@NotNull
 		Difficulty difficulty,
+		PastProblem pastProblem,
 		String schoolCode,
 		@Size(min = 1, max = 100)
 		Set<String> answers,
@@ -36,6 +38,7 @@ class Requests {
 				answerType,
 				coursePath,
 				difficulty,
+				pastProblem,
 				schoolCode,
 				answers,
 				year,

--- a/app/api/mathrank-problem-read-api/build.gradle
+++ b/app/api/mathrank-problem-read-api/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 
     implementation project(':app:api:mathrank-api-common')
     implementation project(':domain:mathrank-problem-read-domain')
+    implementation project(':domain:mathrank-problem-core-domain')
 
     implementation project(':common:mathrank-page')
 }

--- a/app/api/mathrank-problem-read-api/src/main/java/kr/co/mathrank/app/api/problem/read/ProblemQueryRequest.java
+++ b/app/api/mathrank-problem-read-api/src/main/java/kr/co/mathrank/app/api/problem/read/ProblemQueryRequest.java
@@ -3,6 +3,7 @@ package kr.co.mathrank.app.api.problem.read;
 import jakarta.validation.constraints.NotNull;
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 import kr.co.mathrank.domain.problem.read.dto.ProblemReadQuery;
 
 public record ProblemQueryRequest(
@@ -12,6 +13,7 @@ public record ProblemQueryRequest(
 	Difficulty difficultyMinInclude,
 	Difficulty difficultyMaxInclude,
 	AnswerType answerType,
+	PastProblem pastProblem,
 	String coursePath,
 	Boolean videoExist,
 	Integer year,
@@ -27,6 +29,7 @@ public record ProblemQueryRequest(
 			difficultyMinInclude,
 			difficultyMaxInclude,
 			answerType,
+			pastProblem,
 			coursePath,
 			videoExist,
 			year,

--- a/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemQueryRequest.java
+++ b/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemQueryRequest.java
@@ -2,6 +2,7 @@ package kr.co.mathrank.app.api.problem.single.read;
 
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelQuery;
 
 public record SingleProblemQueryRequest(
@@ -16,6 +17,8 @@ public record SingleProblemQueryRequest(
 	String schoolCode,
 
 	AnswerType answerType,
+
+	PastProblem pastProblem,
 
 	Difficulty difficultyMinInclude,
 	Difficulty difficultyMaxInclude,
@@ -34,6 +37,7 @@ public record SingleProblemQueryRequest(
 			location,
 			schoolCode,
 			answerType,
+			pastProblem,
 			difficultyMinInclude,
 			difficultyMaxInclude,
 			accuracyMinInclude,

--- a/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemReadModelResponse.java
+++ b/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemReadModelResponse.java
@@ -2,6 +2,7 @@ package kr.co.mathrank.app.api.problem.single.read;
 
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 import kr.co.mathrank.domain.problem.single.read.dto.CourseContainsParentResult;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelQueryResult;
 
@@ -16,6 +17,7 @@ public record SingleProblemReadModelResponse(
 
 	AnswerType answerType,
 	Difficulty difficulty,
+	PastProblem pastProblem,
 	Long firstTrySuccessCount, // 첫번째 시도에서 성공한 횟수
 	Long totalAttemptedCount, // 문제를 풀려고 시도한 총 횟수
 	Long attemptedUserDistinctCount, // 해당 문제를 풀려고 한 사용자 수
@@ -31,6 +33,7 @@ public record SingleProblemReadModelResponse(
 			result.courseInfo(),
 			result.answerType(),
 			result.difficulty(),
+			result.pastProblem(),
 			result.firstTrySuccessCount(),
 			result.totalAttemptedCount(),
 			result.attemptedUserDistinctCount(),

--- a/app/consumer/mathrank-problem-single-consumer/src/main/java/kr/co/mathrank/app/consumer/problem/single/ProblemUpdatedPayload.java
+++ b/app/consumer/mathrank-problem-single-consumer/src/main/java/kr/co/mathrank/app/consumer/problem/single/ProblemUpdatedPayload.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import kr.co.mathrank.common.event.EventPayload;
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelUpdateCommand;
 
 public record ProblemUpdatedPayload(
@@ -15,10 +16,11 @@ public record ProblemUpdatedPayload(
 	String schoolCode,
 	AnswerType answerType,
 	Difficulty difficulty,
+	PastProblem pastProblem,
 	LocalDateTime updatedAt
 ) implements EventPayload {
 	public SingleProblemReadModelUpdateCommand toCommand() {
 		return new SingleProblemReadModelUpdateCommand(problemId, coursePath, problemImage, location, schoolCode, answerType, difficulty,
-			updatedAt);
+			pastProblem, updatedAt);
 	}
 }

--- a/app/consumer/mathrank-problem-single-consumer/src/test/java/kr/co/mathrank/app/consumer/problem/single/SingleProblemReadModelConsumerTest.java
+++ b/app/consumer/mathrank-problem-single-consumer/src/test/java/kr/co/mathrank/app/consumer/problem/single/SingleProblemReadModelConsumerTest.java
@@ -21,6 +21,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import kr.co.mathrank.common.event.Event;
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemAttemptStatsUpdateCommand;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelUpdateCommand;
 import kr.co.mathrank.domain.problem.single.read.service.SingleProblemUpdateService;
@@ -54,6 +55,7 @@ class SingleProblemReadModelConsumerTest {
 			null,
 			AnswerType.MULTIPLE_CHOICE,
 			Difficulty.LOW,
+			PastProblem.NONE,
 			LocalDateTime.now()
 		);
 		final Event<ProblemUpdatedPayload> event = Event.of(1L, payload);

--- a/app/consumer/mathrank-problem-single-read-consumer-monolith/src/main/java/kr/co/mathrank/app/consumer/problem/single/read/consumer/monolith/EventPayloads.java
+++ b/app/consumer/mathrank-problem-single-read-consumer-monolith/src/main/java/kr/co/mathrank/app/consumer/problem/single/read/consumer/monolith/EventPayloads.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import kr.co.mathrank.common.event.EventPayload;
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemAttemptStatsUpdateCommand;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelRegisterCommand;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelUpdateCommand;
@@ -68,6 +69,7 @@ public class EventPayloads {
 		AnswerType answerType,
 		Difficulty difficulty,
 		LocalDateTime registeredAt,
+		PastProblem pastProblem,
 		Long firstTrySuccessCount, // 첫 시도에 성공한 횟수
 		Long totalAttemptedCount, // 문제를 풀려고 시도한 총 횟수
 		Long attemptedUserDistinctCount // 해당 문제를 풀려고 한 사용자 수
@@ -82,6 +84,7 @@ public class EventPayloads {
 				problemImage,
 				answerType,
 				difficulty,
+				pastProblem,
 				coursePath,
 				registeredAt
 			);

--- a/app/consumer/mathrank-problem-single-read-consumer-monolith/src/main/java/kr/co/mathrank/app/consumer/problem/single/read/consumer/monolith/EventPayloads.java
+++ b/app/consumer/mathrank-problem-single-read-consumer-monolith/src/main/java/kr/co/mathrank/app/consumer/problem/single/read/consumer/monolith/EventPayloads.java
@@ -17,6 +17,7 @@ public class EventPayloads {
 		String problemImage,
 		AnswerType answerType,
 		Difficulty difficulty,
+		PastProblem pastProblem,
 		LocalDateTime updatedAt,
 		Integer year,
 		String schoolCode,

--- a/app/consumer/mathrank-problem-single-read-consumer-monolith/src/main/java/kr/co/mathrank/app/consumer/problem/single/read/consumer/monolith/EventPayloads.java
+++ b/app/consumer/mathrank-problem-single-read-consumer-monolith/src/main/java/kr/co/mathrank/app/consumer/problem/single/read/consumer/monolith/EventPayloads.java
@@ -33,6 +33,7 @@ public class EventPayloads {
 				schoolCode,
 				answerType,
 				difficulty,
+				pastProblem,
 				updatedAt
 			);
 		}

--- a/client/internal/mathrank-problem-client/src/main/java/kr/co/mathrank/client/internal/problem/ProblemQueryResult.java
+++ b/client/internal/mathrank-problem-client/src/main/java/kr/co/mathrank/client/internal/problem/ProblemQueryResult.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 
 public record ProblemQueryResult(
 	Long id,
@@ -13,6 +14,7 @@ public record ProblemQueryResult(
 	String path,
 	Difficulty difficulty,
 	AnswerType type,
+	PastProblem pastProblem,
 	String schoolCode,
 	Set<String> answer,
 	LocalDateTime createdAt,

--- a/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentDifficultyServiceTest.java
+++ b/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentDifficultyServiceTest.java
@@ -61,6 +61,7 @@ class AssessmentDifficultyServiceTest {
 			null,
 			null,
 			null,
+			null,
 			null
 		);
 	}

--- a/domain/mathrank-problem-core-domain/src/main/java/kr/co/mathrank/domain/problem/core/PastProblem.java
+++ b/domain/mathrank-problem-core-domain/src/main/java/kr/co/mathrank/domain/problem/core/PastProblem.java
@@ -1,0 +1,8 @@
+package kr.co.mathrank.domain.problem.core;
+
+public enum PastProblem {
+	NONE,
+	HIGH_SCHOOL_1,   // 고1
+	HIGH_SCHOOL_2,   // 고2
+	HIGH_SCHOOL_3   // 고3
+}

--- a/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/dto/ProblemQuery.java
+++ b/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/dto/ProblemQuery.java
@@ -2,6 +2,7 @@ package kr.co.mathrank.domain.problem.dto;
 
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 
 public record ProblemQuery(
 	Long memberId,
@@ -11,6 +12,7 @@ public record ProblemQuery(
 	AnswerType answerType,
 	String path,
 	Boolean solutionVideoExist,
+	PastProblem pastProblem,
 	Integer year,
 	String location,
 	String schoolCode

--- a/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/dto/ProblemQueryResult.java
+++ b/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/dto/ProblemQueryResult.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 import kr.co.mathrank.domain.problem.entity.Problem;
 
 public record ProblemQueryResult(
@@ -13,6 +14,7 @@ public record ProblemQueryResult(
 	String imageSource,
 	String path,
 	Difficulty difficulty,
+	PastProblem pastProblem,
 	AnswerType type,
 	String schoolCode,
 	Set<String> answer,
@@ -31,6 +33,7 @@ public record ProblemQueryResult(
 			// null 대비
 			String.valueOf(problem.getCoursePath()),
 			problem.getDifficulty(),
+			problem.getPastProblem(),
 			problem.getType(),
 			problem.getSchoolCode(),
 			problem.getAnswers(),

--- a/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/dto/ProblemRegisterCommand.java
+++ b/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/dto/ProblemRegisterCommand.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 
 public record ProblemRegisterCommand(
 	@NotNull
@@ -21,6 +22,7 @@ public record ProblemRegisterCommand(
 	String coursePath,
 	@NotNull
 	Difficulty difficulty,
+	PastProblem pastProblem,
 	String schoolCode,
 	@Size(min = 1, max = 100)
 	Set<String> answers,

--- a/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/dto/ProblemRegisterCommand.java
+++ b/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/dto/ProblemRegisterCommand.java
@@ -22,6 +22,7 @@ public record ProblemRegisterCommand(
 	String coursePath,
 	@NotNull
 	Difficulty difficulty,
+	@NotNull
 	PastProblem pastProblem,
 	String schoolCode,
 	@Size(min = 1, max = 100)

--- a/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/dto/ProblemUpdateCommand.java
+++ b/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/dto/ProblemUpdateCommand.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 
 public record ProblemUpdateCommand(
 	@NotNull
@@ -20,6 +21,7 @@ public record ProblemUpdateCommand(
 	AnswerType answerType,
 	@NotNull
 	Difficulty difficulty,
+	PastProblem pastProblem,
 	@NotNull
 	String coursePath,
 	String schoolCode,

--- a/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/dto/ProblemUpdateCommand.java
+++ b/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/dto/ProblemUpdateCommand.java
@@ -21,6 +21,7 @@ public record ProblemUpdateCommand(
 	AnswerType answerType,
 	@NotNull
 	Difficulty difficulty,
+	@NotNull
 	PastProblem pastProblem,
 	@NotNull
 	String coursePath,

--- a/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/entity/Problem.java
+++ b/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/entity/Problem.java
@@ -22,6 +22,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -36,7 +37,8 @@ import lombok.extern.slf4j.Slf4j;
 	@Index(name = "idx_difficulty", columnList = "difficulty"),
 	@Index(name = "idx_type", columnList = "type"),
 	@Index(name = "idx_videoLink", columnList = "solution_video_link"),
-	@Index(name = "idx_location", columnList = "location")
+	@Index(name = "idx_location", columnList = "location"),
+	@Index(name = "idx_pastProblem", columnList = "past_problem")
 })
 @Getter
 @Setter
@@ -59,6 +61,9 @@ public class Problem implements Persistable<Long> {
 
 	@Enumerated(EnumType.STRING)
 	private AnswerType type;
+
+	@Enumerated(EnumType.STRING)
+	private PastProblem pastProblem;
 
 	private String coursePath;
 

--- a/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/repository/ProblemQueryRepositoryImpl.java
+++ b/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/repository/ProblemQueryRepositoryImpl.java
@@ -9,6 +9,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 import kr.co.mathrank.domain.problem.dto.ProblemQuery;
 import kr.co.mathrank.domain.problem.entity.Problem;
 import kr.co.mathrank.domain.problem.entity.QProblem;
@@ -66,7 +67,16 @@ class ProblemQueryRepositoryImpl implements ProblemQueryRepository {
 			yearMatch(problemQuery.year()),
 			locationMatch(problemQuery.location()),
 			schoolCodeMatch(problemQuery.schoolCode()),
+			pastProblemMatch(problemQuery.pastProblem())
 		};
+	}
+
+	private BooleanExpression pastProblemMatch(final PastProblem pastProblem) {
+		if (pastProblem == null) {
+			return null;
+		}
+
+		return QProblem.problem.pastProblem.eq(pastProblem);
 	}
 
 	private BooleanExpression schoolCodeMatch(final String schoolCode) {

--- a/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/service/ProblemService.java
+++ b/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/service/ProblemService.java
@@ -50,6 +50,8 @@ command.schoolCode(),
 			command.schoolCode() == null ? null : schoolLocationManager.getSchoolLocation(command.schoolCode()),
 			command.memo()
 		);
+		problem.setPastProblem(command.pastProblem()); // of 도저히 못바꾸겠어서 그냥 setter 로 추가했어요 ㅠㅠ
+
 		final Set<Answer> answers = mapToAnswer(command.answers(), problem);
 		problem.setAnswers(answers);
 

--- a/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/service/ProblemUpdateManager.java
+++ b/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/service/ProblemUpdateManager.java
@@ -12,6 +12,7 @@ import kr.co.mathrank.common.outbox.TransactionalOutboxPublisher;
 import kr.co.mathrank.common.snowflake.Snowflake;
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 import kr.co.mathrank.domain.problem.dto.ProblemUpdateCommand;
 import kr.co.mathrank.domain.problem.entity.Answer;
 import kr.co.mathrank.domain.problem.entity.Problem;
@@ -47,6 +48,7 @@ class ProblemUpdateManager {
 		problem.setSchoolCode(command.schoolCode());
 		problem.setMemo(command.memo());
 		problem.setLocation(schoolLocation);
+		problem.setPastProblem(command.pastProblem());
 
 		problem.setUpdatedAt(LocalDateTime.now());
 
@@ -63,6 +65,7 @@ class ProblemUpdateManager {
 			problem.getProblemImage(),
 			problem.getType(),
 			problem.getDifficulty(),
+			problem.getPastProblem(),
 			problem.getUpdatedAt(),
 			problem.getYears(),
 			problem.getSchoolCode(),
@@ -92,6 +95,7 @@ class ProblemUpdateManager {
 		String problemImage,
 		AnswerType answerType,
 		Difficulty difficulty,
+		PastProblem pastProblem,
 		LocalDateTime updatedAt,
 		Integer year,
 		String schoolCode,

--- a/domain/mathrank-problem-domain/src/test/java/kr/co/mathrank/domain/problem/repository/ProblemRepositoryTest.java
+++ b/domain/mathrank-problem-domain/src/test/java/kr/co/mathrank/domain/problem/repository/ProblemRepositoryTest.java
@@ -15,6 +15,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 import kr.co.mathrank.domain.problem.dto.ProblemQuery;
 import kr.co.mathrank.domain.problem.entity.Answer;
 import kr.co.mathrank.domain.problem.entity.Problem;
@@ -41,7 +42,7 @@ class ProblemRepositoryTest {
 		problemRepository.save(owner1);
 		problemRepository.save(owner2);
 
-		final List<Problem> problems = problemRepository.query(new ProblemQuery(1L, null, null, null, null, null, null, 1001, null, null), 10,
+		final List<Problem> problems = problemRepository.query(new ProblemQuery(1L, null, null, null, null, null, null, null, 1001, null, null), 10,
 			1);
 
 		Assertions.assertEquals(1, problems.size());
@@ -61,7 +62,7 @@ class ProblemRepositoryTest {
 		problemRepository.save(problem);
 
 		final List<Problem> problems = problemRepository.query(
-			new ProblemQuery(null, problemId, null, null, null, null, null, 1001,
+			new ProblemQuery(null, problemId, null, null, null, null, null, null, 1001,
 				null, null), 10, 1);
 
 		Assertions.assertEquals(1, problems.size());
@@ -78,7 +79,7 @@ class ProblemRepositoryTest {
 		problemRepository.save(problem1);
 		problemRepository.save(problem2);
 
-		final List<Problem> problems = problemRepository.query(new ProblemQuery(null, null, null, null, null, null, null, 1001, null, null), 10,
+		final List<Problem> problems = problemRepository.query(new ProblemQuery(null, null, null, null, null, null, null, null, 1001, null, null), 10,
 			1);
 
 		Assertions.assertEquals(2, problems.size());
@@ -100,7 +101,7 @@ class ProblemRepositoryTest {
 
 		final List<Problem> problems = problemRepository.query(
 			new ProblemQuery(null, null, Difficulty.KILLER, Difficulty.KILLER, null,
-				null, null, 1001, null, null), 10, 1);
+				null, null, null, 1001, null, null), 10, 1);
 
 		Assertions.assertEquals(1, problems.size());
 	}
@@ -119,7 +120,7 @@ class ProblemRepositoryTest {
 		final List<Problem> problems = problemRepository.query(
 			new ProblemQuery(1L, null, Difficulty.KILLER, Difficulty.KILLER,
 				AnswerType.MULTIPLE_CHOICE,
-				"testPath", null, 1001, null, null), 10, 1);
+				"testPath", null, null, 1001, null, null), 10, 1);
 
 		Assertions.assertEquals(1, problems.size());
 	}
@@ -137,7 +138,7 @@ class ProblemRepositoryTest {
 
 		final List<Problem> problems = problemRepository.query(
 			new ProblemQuery(null, null, Difficulty.HIGH, Difficulty.HIGH, null, null,
-				null, 1001, null, null), 10, 1);
+				null, null, 1001, null, null), 10, 1);
 
 		Assertions.assertTrue(problems.isEmpty());
 	}
@@ -152,7 +153,7 @@ class ProblemRepositoryTest {
 			problemRepository.save(problem);
 		}
 
-		assertEquals(10, problemRepository.count(new ProblemQuery(null, null, null, null, null, null, null, 1001, null, null)));
+		assertEquals(10, problemRepository.count(new ProblemQuery(null, null, null, null, null, null, null, null, 1001, null, null)));
 	}
 
 	@Test
@@ -174,7 +175,7 @@ class ProblemRepositoryTest {
 
 		assertEquals(10,
 			problemRepository.count(
-				new ProblemQuery(null, null, Difficulty.KILLER, Difficulty.KILLER, null, null, null, 1001, null, null)));
+				new ProblemQuery(null, null, Difficulty.KILLER, Difficulty.KILLER, null, null, null, null, 1001, null, null)));
 	}
 
 	@Test
@@ -194,7 +195,7 @@ class ProblemRepositoryTest {
 		}
 
 		assertEquals(20,
-			problemRepository.count(new ProblemQuery(null, null, null, null, null, null, null, 1001, null, null)));
+			problemRepository.count(new ProblemQuery(null, null, null, null, null, null, null, null, 1001, null, null)));
 	}
 
 	@Test
@@ -215,7 +216,7 @@ class ProblemRepositoryTest {
 
 		// 5개 조회
 		final List<Problem> problems = problemRepository.query(
-			new ProblemQuery(1L, null, null, null, null, null, null, 1001, null, null), 5, 1);
+			new ProblemQuery(1L, null, null, null, null, null, null, null, 1001, null, null), 5, 1);
 		// 로그를 확인했을 때, limit과 offset을 활용하는것을 확인
 		Assertions.assertEquals(5, problems.size());
 	}

--- a/domain/mathrank-problem-domain/src/test/java/kr/co/mathrank/domain/problem/service/ProblemQueryServiceTest.java
+++ b/domain/mathrank-problem-domain/src/test/java/kr/co/mathrank/domain/problem/service/ProblemQueryServiceTest.java
@@ -11,6 +11,7 @@ import jakarta.persistence.PersistenceContext;
 import kr.co.mathrank.common.page.PageResult;
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 import kr.co.mathrank.domain.problem.dto.ProblemQuery;
 import kr.co.mathrank.domain.problem.dto.ProblemQueryResult;
 import kr.co.mathrank.domain.problem.entity.Problem;
@@ -38,7 +39,7 @@ class ProblemQueryServiceTest {
 		}
 
 		// memberId가 1인 사용자의 문제를 조회한다.
-		final PageResult<ProblemQueryResult> result = problemQueryService.query(new ProblemQuery(1L, null, null, null, null, null, null, 1001, null, null), 2, 1);
+		final PageResult<ProblemQueryResult> result = problemQueryService.query(new ProblemQuery(1L, null, null, null, null, null, null, null, 1001, null, null), 2, 1);
 
 		// 조회된 문제의 갯수는 2개이고, 전체 페이지는 5페이지이다. ( possibleNextPageNumbers() 가 4개)
 		Assertions.assertEquals(2, result.queryResults().size());

--- a/domain/mathrank-problem-domain/src/test/java/kr/co/mathrank/domain/problem/service/ProblemServiceTest.java
+++ b/domain/mathrank-problem-domain/src/test/java/kr/co/mathrank/domain/problem/service/ProblemServiceTest.java
@@ -56,7 +56,7 @@ class ProblemServiceTest {
 			Set.of("1"), 1001, null, null);
 		final Long problemId = problemService.save(command);
 
-		final ProblemUpdateCommand updateCommand = new ProblemUpdateCommand(problemId, 1L, "newImage.jpeg", "newImage.jpeg", AnswerType.SHORT_ANSWER, Difficulty.KILLER, "testPath", "newTestCode", Set.of("newAnswer"), 1212, "solutionVideoLink", null);
+		final ProblemUpdateCommand updateCommand = new ProblemUpdateCommand(problemId, 1L, "newImage.jpeg", "newImage.jpeg", AnswerType.SHORT_ANSWER, Difficulty.KILLER, PastProblem.NONE, "testPath", "newTestCode", Set.of("newAnswer"), 1212, "solutionVideoLink", null);
 		problemService.update(updateCommand);
 
 		final Problem updatedProblem = problemRepository.findById(problemId)
@@ -76,7 +76,7 @@ class ProblemServiceTest {
 		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE, "testPath", Difficulty.KILLER, PastProblem.NONE, "testCode", Set.of("test"), 1001, null, null);
 		final Long problemId = problemService.save(command);
 
-		final ProblemUpdateCommand updateCommand = new ProblemUpdateCommand(problemId, 2L, "newImage.jpeg", "newImage.jpeg", AnswerType.SHORT_ANSWER, Difficulty.KILLER, "testPath", "newTestCode", Set.of("newAnswer"), 1212, "solutionVideoLink", null);
+		final ProblemUpdateCommand updateCommand = new ProblemUpdateCommand(problemId, 2L, "newImage.jpeg", "newImage.jpeg", AnswerType.SHORT_ANSWER, Difficulty.KILLER, PastProblem.NONE, "testPath", "newTestCode", Set.of("newAnswer"), 1212, "solutionVideoLink", null);
 
 		Assertions.assertThrows(CannotAccessProblemException.class, () -> problemService.update(updateCommand));
 	}

--- a/domain/mathrank-problem-domain/src/test/java/kr/co/mathrank/domain/problem/service/ProblemServiceTest.java
+++ b/domain/mathrank-problem-domain/src/test/java/kr/co/mathrank/domain/problem/service/ProblemServiceTest.java
@@ -20,6 +20,7 @@ import jakarta.persistence.PersistenceContext;
 import jakarta.validation.ConstraintViolationException;
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 import kr.co.mathrank.domain.problem.dto.ProblemDeleteCommand;
 import kr.co.mathrank.domain.problem.dto.ProblemRegisterCommand;
 import kr.co.mathrank.domain.problem.dto.ProblemUpdateCommand;
@@ -51,7 +52,7 @@ class ProblemServiceTest {
 		entityManager.flush();
 		entityManager.clear();
 
-		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE, "testPath", Difficulty.KILLER, "testCode",
+		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE, "testPath", Difficulty.KILLER, PastProblem.NONE, "testCode",
 			Set.of("1"), 1001, null, null);
 		final Long problemId = problemService.save(command);
 
@@ -72,7 +73,7 @@ class ProblemServiceTest {
 		entityManager.flush();
 		entityManager.clear();
 
-		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE, "testPath", Difficulty.KILLER, "testCode", Set.of("test"), 1001, null, null);
+		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE, "testPath", Difficulty.KILLER, PastProblem.NONE, "testCode", Set.of("test"), 1001, null, null);
 		final Long problemId = problemService.save(command);
 
 		final ProblemUpdateCommand updateCommand = new ProblemUpdateCommand(problemId, 2L, "newImage.jpeg", "newImage.jpeg", AnswerType.SHORT_ANSWER, Difficulty.KILLER, "testPath", "newTestCode", Set.of("newAnswer"), 1212, "solutionVideoLink", null);
@@ -85,7 +86,7 @@ class ProblemServiceTest {
 		entityManager.flush();
 		entityManager.clear();
 
-		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE, "testPath", Difficulty.KILLER, "testCode", Set.of("answer"), 1001, null, null);
+		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE, "testPath", Difficulty.KILLER, PastProblem.NONE, "testCode", Set.of("answer"), 1001, null, null);
 		final Long problemId = problemService.save(command);
 
 		entityManager.flush();
@@ -106,7 +107,7 @@ class ProblemServiceTest {
 		entityManager.clear();
 
 		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE,
-			"testPath", Difficulty.KILLER, "testCode", Set.of("answer"), 1001, null, null);
+			"testPath", Difficulty.KILLER, PastProblem.NONE, "testCode", Set.of("answer"), 1001, null, null);
 		final Long problemId = problemService.save(command);
 
 		final ProblemDeleteCommand deleteCommand = new ProblemDeleteCommand(problemId, 2L);
@@ -116,13 +117,13 @@ class ProblemServiceTest {
 
 	private static Stream<Arguments> argumentsStream() {
 		return Stream.of(
-			Arguments.of(new ProblemRegisterCommand(			null, "image.jpeg", null, AnswerType.MULTIPLE_CHOICE, "aa", Difficulty.KILLER, "testCode", Set.of("answer"), 1001, null, null)),
-			Arguments.of(new ProblemRegisterCommand(			1L, null, null, AnswerType.MULTIPLE_CHOICE, "aa", Difficulty.KILLER, "testCode", Set.of("answer"), 1001, null, null)),
-			Arguments.of(new ProblemRegisterCommand(			1L, "image.jpeg", null, null, "aa", Difficulty.KILLER, "testCode", Set.of("answer"), 1001, null, null)),
-			Arguments.of(new ProblemRegisterCommand(			1L, "image.jpeg", null, AnswerType.MULTIPLE_CHOICE, "aa", null, "testCode", Set.of("answer"), 1001, null, null)),
-			Arguments.of(new ProblemRegisterCommand(			1L, "image.jpeg", null, AnswerType.MULTIPLE_CHOICE, "aa", Difficulty.KILLER, null, Set.of("answer"), 1001, null, null)),
-			Arguments.of(new ProblemRegisterCommand(			1L, "image.jpeg", null, AnswerType.MULTIPLE_CHOICE, "aa", Difficulty.KILLER, "testCode", Set.of(), 1001, null, null)),
-			Arguments.of(new ProblemRegisterCommand(			1L, "image.jpeg", null, AnswerType.MULTIPLE_CHOICE, "aa", Difficulty.KILLER, "testCode", null, 1001, null, null))
+			Arguments.of(new ProblemRegisterCommand(			null, "image.jpeg", null, AnswerType.MULTIPLE_CHOICE, "aa", Difficulty.KILLER, PastProblem.NONE, "testCode", Set.of("answer"), 1001, null, null)),
+			Arguments.of(new ProblemRegisterCommand(			1L, null, null, AnswerType.MULTIPLE_CHOICE, "aa", Difficulty.KILLER, PastProblem.NONE, "testCode", Set.of("answer"), 1001, null, null)),
+			Arguments.of(new ProblemRegisterCommand(			1L, "image.jpeg", null, null, "aa", Difficulty.KILLER, PastProblem.NONE, "testCode", Set.of("answer"), 1001, null, null)),
+			Arguments.of(new ProblemRegisterCommand(			1L, "image.jpeg", null, AnswerType.MULTIPLE_CHOICE, "aa", null, PastProblem.NONE, "testCode", Set.of("answer"), 1001, null, null)),
+			Arguments.of(new ProblemRegisterCommand(			1L, "image.jpeg", null, AnswerType.MULTIPLE_CHOICE, "aa", Difficulty.KILLER, PastProblem.NONE, null, Set.of("answer"), 1001, null, null)),
+			Arguments.of(new ProblemRegisterCommand(			1L, "image.jpeg", null, AnswerType.MULTIPLE_CHOICE, "aa", Difficulty.KILLER, PastProblem.NONE, "testCode", Set.of(), 1001, null, null)),
+			Arguments.of(new ProblemRegisterCommand(			1L, "image.jpeg", null, AnswerType.MULTIPLE_CHOICE, "aa", Difficulty.KILLER, PastProblem.NONE, "testCode", null, 1001, null, null))
 		);
 	}
 }

--- a/domain/mathrank-problem-domain/src/test/java/kr/co/mathrank/domain/problem/service/ProblemSolveServiceTest.java
+++ b/domain/mathrank-problem-domain/src/test/java/kr/co/mathrank/domain/problem/service/ProblemSolveServiceTest.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 import kr.co.mathrank.domain.problem.dto.ProblemRegisterCommand;
 import kr.co.mathrank.domain.problem.dto.ProblemSolveCommand;
 import kr.co.mathrank.domain.problem.dto.ProblemSolveResult;
@@ -33,7 +34,7 @@ class ProblemSolveServiceTest {
 	void 제출된_정답이_실제_정답이랑_정확히_일치할때_성공한다() {
 		Mockito.when(schoolLocationManager.getSchoolLocation(Mockito.anyString())).thenReturn("test");
 
-		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE, "testPath", Difficulty.KILLER, "testCode",
+		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE, "testPath", Difficulty.KILLER, PastProblem.NONE, "testCode",
 			Set.of("1"), 1001, null, null);
 
 		final Long problemId = problemService.save(command);
@@ -49,7 +50,7 @@ class ProblemSolveServiceTest {
 	void 제출된_정답이_일치하지만_더많으면_실패한다() {
 		Mockito.when(schoolLocationManager.getSchoolLocation(Mockito.anyString())).thenReturn("test");
 
-		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE, "testPath", Difficulty.KILLER, "testCode",
+		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE, "testPath", Difficulty.KILLER, PastProblem.NONE, "testCode",
 			Set.of("1"), 1001, null, null);
 		final Long problemId = problemService.save(command);
 
@@ -65,7 +66,7 @@ class ProblemSolveServiceTest {
 	void 제출된_정답에_정답이_포함되지_않으면_실패한다() {
 		Mockito.when(schoolLocationManager.getSchoolLocation(Mockito.anyString())).thenReturn("test");
 
-		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE, "testPath", Difficulty.KILLER, "testCode",
+		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE, "testPath", Difficulty.KILLER, PastProblem.NONE, "testCode",
 			Set.of("1"), 1001, null, null);
 		final Long problemId = problemService.save(command);
 

--- a/domain/mathrank-problem-read-domain/src/main/java/kr/co/mathrank/domain/problem/read/dto/ProblemReadQuery.java
+++ b/domain/mathrank-problem-read-domain/src/main/java/kr/co/mathrank/domain/problem/read/dto/ProblemReadQuery.java
@@ -2,6 +2,7 @@ package kr.co.mathrank.domain.problem.read.dto;
 
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 import kr.co.mathrank.domain.problem.dto.ProblemQuery;
 
 public record ProblemReadQuery(
@@ -10,6 +11,7 @@ public record ProblemReadQuery(
 	Difficulty difficultyMinInclude,
 	Difficulty difficultyMaxInclude,
 	AnswerType answerType,
+	PastProblem pastProblem,
 	String path,
 	Boolean solutionVideoExist,
 	Integer year,
@@ -25,6 +27,7 @@ public record ProblemReadQuery(
 			answerType,
 			path,
 			solutionVideoExist,
+			pastProblem,
 			year,
 			location,
 			schoolCode

--- a/domain/mathrank-problem-read-domain/src/main/java/kr/co/mathrank/domain/problem/read/dto/ProblemResponse.java
+++ b/domain/mathrank-problem-read-domain/src/main/java/kr/co/mathrank/domain/problem/read/dto/ProblemResponse.java
@@ -8,6 +8,7 @@ import kr.co.mathrank.client.internal.course.CourseQueryContainsParentsResult;
 import kr.co.mathrank.client.internal.member.MemberInfo;
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 import kr.co.mathrank.domain.problem.dto.ProblemQueryResult;
 
 public record ProblemResponse(
@@ -17,6 +18,7 @@ public record ProblemResponse(
 	String problemImage,
 	String solutionImage,
 	Difficulty difficulty,
+	PastProblem pastProblem,
 	AnswerType type,
 	SchoolResponse schoolInfo,
 	Set<String> answers,
@@ -38,6 +40,7 @@ public record ProblemResponse(
 			result.imageSource(),
 			result.solutionImage(),
 			result.difficulty(),
+			result.pastProblem(),
 			result.type(),
 			SchoolResponse.from(schoolInfo),
 			result.answer(),

--- a/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/service/SingleProblemRegisterManager.java
+++ b/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/service/SingleProblemRegisterManager.java
@@ -12,6 +12,7 @@ import kr.co.mathrank.common.event.EventPayload;
 import kr.co.mathrank.common.outbox.TransactionalOutboxPublisher;
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 import kr.co.mathrank.domain.problem.single.entity.SingleProblem;
 import kr.co.mathrank.domain.problem.single.repository.SingleProblemRepository;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +41,7 @@ class SingleProblemRegisterManager {
 			result.schoolCode(),
 			result.type(),
 			result.difficulty(),
+			result.pastProblem(),
 			problem.getSingleProblemRegisteredAt(),
 			problem.getFirstTrySuccessCount(),
 			problem.getTotalAttemptedCount(),
@@ -57,6 +59,7 @@ class SingleProblemRegisterManager {
 		String schoolCode,
 		AnswerType answerType,
 		Difficulty difficulty,
+		PastProblem pastProblem,
 		LocalDateTime registeredAt,
 		Long firstTrySuccessCount, // 첫 시도에 성공한 횟수
 		Long totalAttemptedCount, // 문제를 풀려고 시도한 총 횟수

--- a/domain/mathrank-problem-single-domain/src/test/java/kr/co/mathrank/domain/problem/single/service/SingleProblemServiceTest.java
+++ b/domain/mathrank-problem-single-domain/src/test/java/kr/co/mathrank/domain/problem/single/service/SingleProblemServiceTest.java
@@ -100,6 +100,7 @@ class SingleProblemServiceTest {
 			null,
 			null,
 			null,
+			null,
 			null, null,
 			null,
 			null,

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemReadModelQuery.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemReadModelQuery.java
@@ -2,6 +2,7 @@ package kr.co.mathrank.domain.problem.single.read.dto;
 
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 
 public record SingleProblemReadModelQuery(
 	Long singleProblemId,
@@ -15,6 +16,8 @@ public record SingleProblemReadModelQuery(
 	String schoolCode,
 
 	AnswerType answerType,
+
+	PastProblem pastProblem,
 
 	Difficulty difficultyMinInclude,
 	Difficulty difficultyMaxInclude,

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemReadModelQueryResult.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemReadModelQueryResult.java
@@ -2,6 +2,7 @@ package kr.co.mathrank.domain.problem.single.read.dto;
 
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 import kr.co.mathrank.domain.problem.single.read.entity.SingleProblemReadModel;
 
 public record SingleProblemReadModelQueryResult(
@@ -13,6 +14,7 @@ public record SingleProblemReadModelQueryResult(
 	CourseContainsParentResult courseInfo,
 	String location,
 	String schoolCode,
+	PastProblem pastProblem,
 	AnswerType answerType,
 	Difficulty difficulty,
 	Long firstTrySuccessCount, // 첫번째 시도에서 성공한 횟수
@@ -34,6 +36,7 @@ public record SingleProblemReadModelQueryResult(
 			courseContainsParentResult,
 			model.getLocation(),
 			model.getSchoolCode(),
+			model.getPastProblem(),
 			model.getAnswerType(),
 			model.getDifficulty(),
 			model.getFirstTrySuccessCount(),
@@ -56,6 +59,7 @@ public record SingleProblemReadModelQueryResult(
 			courseQueryResult,
 			model.location(),
 			model.schoolCode(),
+			model.pastProblem(),
 			model.answerType(),
 			model.difficulty(),
 			model.firstTrySuccessCount(),

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemReadModelRegisterCommand.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemReadModelRegisterCommand.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import jakarta.validation.constraints.NotNull;
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 
 public record SingleProblemReadModelRegisterCommand(
 	@NotNull
@@ -20,6 +21,7 @@ public record SingleProblemReadModelRegisterCommand(
 	AnswerType answerType,
 	@NotNull
 	Difficulty difficulty,
+	PastProblem pastProblem,
 	@NotNull
 	String coursePath,
 	@NotNull

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemReadModelResult.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemReadModelResult.java
@@ -2,6 +2,7 @@ package kr.co.mathrank.domain.problem.single.read.dto;
 
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 import kr.co.mathrank.domain.problem.single.read.entity.SingleProblemReadModel;
 
 public record SingleProblemReadModelResult(
@@ -15,6 +16,7 @@ public record SingleProblemReadModelResult(
 	String schoolCode,
 	AnswerType answerType,
 	Difficulty difficulty,
+	PastProblem pastProblem,
 	Long firstTrySuccessCount, // 첫번째 시도에서 성공한 횟수
 	Long totalAttemptedCount, // 문제를 풀려고 시도한 총 횟수
 	Long attemptedUserDistinctCount, // 해당 문제를 풀려고 한 사용자 수
@@ -32,6 +34,7 @@ public record SingleProblemReadModelResult(
 			model.getSchoolCode(),
 			model.getAnswerType(),
 			model.getDifficulty(),
+			model.getPastProblem(),
 			model.getFirstTrySuccessCount(),
 			model.getTotalAttemptedCount(),
 			model.getAttemptedUserDistinctCount(),

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemReadModelUpdateCommand.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemReadModelUpdateCommand.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import jakarta.validation.constraints.NotNull;
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 
 public record SingleProblemReadModelUpdateCommand(
 	@NotNull
@@ -19,6 +20,7 @@ public record SingleProblemReadModelUpdateCommand(
 	AnswerType answerType,
 	@NotNull
 	Difficulty difficulty,
+	PastProblem pastProblem,
 	@NotNull
 	LocalDateTime updatedAt
 ) {

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemReadModel.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemReadModel.java
@@ -43,6 +43,7 @@ import lombok.ToString;
 	@Index(name = "idx_firstTrySuccessCount", columnList = "first_try_success_count desc"),
 	@Index(name = "idx_attemptedUserDistinctCount", columnList = "attempted_user_distinct_count desc"),
 	@Index(name = "idx_accuracy", columnList = "accuracy desc"),
+	@Index(name = "idx_pastProblem", columnList = "past_problem"),
 })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Setter

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemReadModel.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemReadModel.java
@@ -24,6 +24,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -70,6 +71,9 @@ public class SingleProblemReadModel implements Persistable<Long> {
 
 	@Convert(converter = DifficultyConverter.class)
 	private Difficulty difficulty;
+
+	@Enumerated(EnumType.STRING)
+	private PastProblem pastProblem;
 
 	private Long firstTrySuccessCount = 0L; // 첫번째 시도에서 성공한 횟수
 

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelQueryRepositoryImpl.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelQueryRepositoryImpl.java
@@ -11,6 +11,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelQuery;
 import kr.co.mathrank.domain.problem.single.read.entity.OrderColumn;
 import kr.co.mathrank.domain.problem.single.read.entity.OrderDirection;
@@ -76,8 +77,17 @@ class SingleProblemReadModelQueryRepositoryImpl implements SingleProblemReadMode
 			answerTypeEqual(query.answerType()),
 			containsSingleProblemName(query.singleProblemName()),
 			startsWithLocation(query.location()),
-			schoolCodeMatch(query.schoolCode())
+			schoolCodeMatch(query.schoolCode()),
+			pastProblemMatch(query.pastProblem())
 		};
+	}
+
+	private BooleanExpression pastProblemMatch(final PastProblem pastProblem) {
+		if (pastProblem == null) {
+			return null;
+		}
+
+		return QSingleProblemReadModel.singleProblemReadModel.pastProblem.eq(pastProblem);
 	}
 
 	private BooleanExpression schoolCodeMatch(final String schoolCode) {

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelRepository.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelRepository.java
@@ -23,7 +23,7 @@ public interface SingleProblemReadModelRepository
 
 	@Query(
 """
-	SELECT new kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelResult(sp.id, slv.success, sp.problemId, sp.singleProblemName, sp.problemImage, sp.coursePath, sp.location, sp.schoolCode, sp.answerType, sp.difficulty, sp.firstTrySuccessCount, sp.totalAttemptedCount, sp.attemptedUserDistinctCount, sp.accuracy) 
+	SELECT new kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelResult(sp.id, slv.success, sp.problemId, sp.singleProblemName, sp.problemImage, sp.coursePath, sp.location, sp.schoolCode, sp.answerType, sp.difficulty, sp.pastProblem, sp.firstTrySuccessCount, sp.totalAttemptedCount, sp.attemptedUserDistinctCount, sp.accuracy) 
 	 FROM SingleProblemReadModel sp 
 	 LEFT JOIN sp.solvers slv WITH slv.memberId = :memberId
 	 WHERE sp.id = :singleProblemId

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemReadModelRegisterService.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemReadModelRegisterService.java
@@ -27,6 +27,7 @@ public class SingleProblemReadModelRegisterService {
 			command.createdAt());
 		model.setLocation(command.location());
 		model.setSchoolCode(command.schoolCode());
+		model.setPastProblem(command.pastProblem());
 
 		singleProblemReadModelRepository.save(model);
 	}

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemUpdateService.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemUpdateService.java
@@ -51,6 +51,7 @@ public class SingleProblemUpdateService {
 			model.setDifficulty(command.difficulty());
 			model.setCoursePath(command.coursePath());
 			model.setAnswerType(command.answerType());
+			model.setPastProblem(command.pastProblem());
 			model.setLocation(command.location());
 			model.setSchoolCode(command.schoolCode());
 

--- a/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelRepositoryTest.java
+++ b/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelRepositoryTest.java
@@ -106,6 +106,7 @@ class SingleProblemReadModelRepositoryTest {
 				null,
 				null,
 				null,
+				null,
 				null
 			),
 			10,
@@ -172,6 +173,7 @@ class SingleProblemReadModelRepositoryTest {
 			new SingleProblemReadModelQuery(
 				null,
 				"singleProblemName",
+				null,
 				null,
 				null,
 				null,
@@ -250,6 +252,7 @@ class SingleProblemReadModelRepositoryTest {
 					null,
 					null,
 					null,
+					null,
 					Difficulty.MID,
 					Difficulty.KILLER,
 					null,
@@ -271,6 +274,7 @@ class SingleProblemReadModelRepositoryTest {
 					null,
 					null,
 					null,
+					null,
 					Difficulty.MID,
 					null,
 					null,
@@ -288,6 +292,7 @@ class SingleProblemReadModelRepositoryTest {
 				new SingleProblemReadModelQuery(
 					null,
 					"singleProblemName",
+					null,
 					null,
 					null,
 					null,
@@ -370,6 +375,7 @@ class SingleProblemReadModelRepositoryTest {
 					null,
 					null,
 					null,
+					null,
 					10,
 					30,
 					null,
@@ -385,6 +391,7 @@ class SingleProblemReadModelRepositoryTest {
 				new SingleProblemReadModelQuery(
 					null,
 					"singleProblemName",
+					null,
 					null,
 					null,
 					null,
@@ -420,7 +427,7 @@ class SingleProblemReadModelRepositoryTest {
 			() -> Assertions.assertEquals(2, singleProblemReadModelRepository.queryPage(
 				new SingleProblemReadModelQuery(
 					null, "singleProblemName","math", null,
-					null,null, null, null,
+					null,null, null,null, null,
 					null, null, null, null
 				),
 				10, 1, null, null
@@ -430,7 +437,7 @@ class SingleProblemReadModelRepositoryTest {
 			() -> Assertions.assertEquals(1, singleProblemReadModelRepository.queryPage(
 				new SingleProblemReadModelQuery(
 					null, "singleProblemName", "science", null, null, null,
-					null,null,
+					null, null,null,
 					null, null, null, null
 				),
 				10, 1,
@@ -442,7 +449,7 @@ class SingleProblemReadModelRepositoryTest {
 			() -> Assertions.assertEquals(0, singleProblemReadModelRepository.queryPage(
 				new SingleProblemReadModelQuery(
 					null, "singleProblemName","english", null, null, null,
-					null,null,
+					null, null,null,
 					null, null, null, null
 				),
 				10, 1,
@@ -469,7 +476,7 @@ class SingleProblemReadModelRepositoryTest {
 				new SingleProblemReadModelQuery(
 					null, "singleProblemName",null, null, null, null,
 					null, null,null,
-					null,
+					null, null,
 					200L, 300L
 				),
 				10, 1, null, null
@@ -479,7 +486,7 @@ class SingleProblemReadModelRepositoryTest {
 			() -> Assertions.assertEquals(3, singleProblemReadModelRepository.queryPage(
 				new SingleProblemReadModelQuery(
 					null, "singleProblemName",null, null, null, null,null,
-					null,
+					null, null,
 					null, null,
 					null, 500L
 				),
@@ -492,7 +499,7 @@ class SingleProblemReadModelRepositoryTest {
 			() -> Assertions.assertEquals(1, singleProblemReadModelRepository.queryPage(
 				new SingleProblemReadModelQuery(
 					null, "singleProblemName",null, null, null, null,null,
-					null,
+					null, null,
 					null, null,
 					400L, null
 				),
@@ -530,6 +537,7 @@ class SingleProblemReadModelRepositoryTest {
 			null,
 			null,
 			null,
+			null,
 			Difficulty.MID,
 			Difficulty.MID,
 			30,
@@ -554,7 +562,7 @@ class SingleProblemReadModelRepositoryTest {
 			() -> Assertions.assertEquals(2, singleProblemReadModelRepository.queryPage(
 				new SingleProblemReadModelQuery(
 					null, "singleProblemName",null, null,
-					null, AnswerType.MULTIPLE_CHOICE, null, null,
+					null, AnswerType.MULTIPLE_CHOICE, null, null, null,
 					null, null, null, null
 				), 10, 1, null, null
 			).size()),
@@ -563,7 +571,7 @@ class SingleProblemReadModelRepositoryTest {
 			() -> Assertions.assertEquals(1, singleProblemReadModelRepository.queryPage(
 				new SingleProblemReadModelQuery(
 					null, "singleProblemName",null,null,
-					null, AnswerType.SHORT_ANSWER, null, null,
+					null, AnswerType.SHORT_ANSWER, null, null, null,
 					null, null, null, null
 				),
 				10, 1,
@@ -576,6 +584,7 @@ class SingleProblemReadModelRepositoryTest {
 				new SingleProblemReadModelQuery(
 					null,
 					"singleProblemName",
+					null,
 					null,
 					null,
 					null,
@@ -607,7 +616,7 @@ class SingleProblemReadModelRepositoryTest {
 		// when
 		final SingleProblemReadModelQuery query = new SingleProblemReadModelQuery(
 			null,"problem", null, null,
-			null,null, null, null, null, null, null, null
+			null, null,null, null, null, null, null, null, null
 		);
 		final List<SingleProblemReadModel> result = singleProblemReadModelRepository.queryPage(query, 10, 1, null, null);
 

--- a/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemQueryServiceTest.java
+++ b/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemQueryServiceTest.java
@@ -118,6 +118,7 @@ class SingleProblemQueryServiceTest {
 			null,
 			null,
 			null,
+			null,
 			null
 		);
 		final PageResult<SingleProblemReadModelQueryResult> result = queryService.queryPage(query, null, null, memberId, 10, 1);
@@ -139,7 +140,7 @@ class SingleProblemQueryServiceTest {
 	@Test
 	void 오프셋이_20_000초과로_조회할_수_없다() {
 		final SingleProblemReadModelQuery query = new SingleProblemReadModelQuery(null, "singleProblemName", "math", null, null,
-			null, Difficulty.MID, Difficulty.MID, 10, 30, null, null);
+			null, null, Difficulty.MID, Difficulty.MID, 10, 30, null, null);
 		final Long memberId = 10L;
 
 		Assertions.assertThrows(ConstraintViolationException.class, () -> queryService.queryPage(query, null, null, memberId, 20, 1001));
@@ -162,6 +163,7 @@ class SingleProblemQueryServiceTest {
 			null,
 			"singleProblemName",
 			"math",
+			null,
 			null,
 			null,
 			null,

--- a/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemReadModelRegisterServiceTest.java
+++ b/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemReadModelRegisterServiceTest.java
@@ -47,14 +47,14 @@ class SingleProblemReadModelRegisterServiceTest {
 
 		singleProblemReadModelRegisterService.save(new SingleProblemReadModelRegisterCommand(
 			singleProblemId1, problemId, "singleProblemName", "img", null,
-			null, AnswerType.SHORT_ANSWER, Difficulty.LOW, "initialPath", baseTime
+			null, AnswerType.SHORT_ANSWER, Difficulty.LOW, null, "initialPath", baseTime
 		));
 
 		Assertions.assertDoesNotThrow(
 			() -> singleProblemReadModelRegisterService.save(new SingleProblemReadModelRegisterCommand(
 				// 다른 singleProblemId
 				singleProblemId2, problemId, "singleProblemName", "img", null,
-				null, AnswerType.SHORT_ANSWER, Difficulty.LOW, "initialPath", baseTime
+				null, AnswerType.SHORT_ANSWER, Difficulty.LOW, null, "initialPath", baseTime
 			)));
 	}
 }

--- a/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemUpdateServiceTest.java
+++ b/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemUpdateServiceTest.java
@@ -70,7 +70,7 @@ class SingleProblemUpdateServiceTest {
 		// path를 updatedPath
 		singleProblemUpdateService.updateProblemInfo(new SingleProblemReadModelUpdateCommand(
 			problemId, updatedPath, "null", null,
-			null, AnswerType.MULTIPLE_CHOICE, Difficulty.KILLER, updatedTime
+			null, AnswerType.MULTIPLE_CHOICE, Difficulty.KILLER, null, updatedTime
 		));
 
 		entityManager.flush();
@@ -104,7 +104,7 @@ class SingleProblemUpdateServiceTest {
 		// outdatedTime으로 업데이트 시도
 		singleProblemUpdateService.updateProblemInfo(new SingleProblemReadModelUpdateCommand(
 			problemId, outdatedPath, "img", null,
-			null, AnswerType.MULTIPLE_CHOICE, Difficulty.KILLER, outdatedTime
+			null, AnswerType.MULTIPLE_CHOICE, Difficulty.KILLER, null, outdatedTime
 		));
 
 		entityManager.flush();
@@ -138,7 +138,7 @@ class SingleProblemUpdateServiceTest {
 		// 동일한 시간으로 업데이트 시도
 		singleProblemUpdateService.updateProblemInfo(new SingleProblemReadModelUpdateCommand(
 			problemId, updatedPath, "img", null,
-			null, AnswerType.SHORT_ANSWER, Difficulty.KILLER, time
+			null, AnswerType.SHORT_ANSWER, Difficulty.KILLER, null, time
 		));
 
 		entityManager.flush();
@@ -272,6 +272,7 @@ class SingleProblemUpdateServiceTest {
 								null,
 								AnswerType.MULTIPLE_CHOICE,
 								Difficulty.KILLER,
+								null,
 								updatedAt
 							)
 						);


### PR DESCRIPTION
- 기존 `Problem`도메인에 필드 추가
- `SingleProblemReadModel`에 해당 필드 추가

- 파일 변경내역이 많지만, 대부분 테스트 코드 수정임

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Past Problem classification (NONE, HS1–HS3); settable on create/update and exposed in lists, single-problem pages, query results, and event payloads.

- **Performance**
  - Added indexing to support efficient filtering by Past Problem.

- **Chores**
  - Propagated Past Problem across APIs, read models, consumers, and clients; updated mappings, queries, and tests accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->