### PR TITLE
feat(board): 댓글 수정 기능 구현

### DIFF
--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/dto/CommentUpdateCommand.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/dto/CommentUpdateCommand.java
@@ -1,0 +1,13 @@
+package kr.co.mathrank.domain.board.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CommentUpdateCommand(
+	@NotNull
+	Long commentId,
+	@NotNull
+	Long memberId,
+	@NotNull
+	String content
+) {
+}

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/entity/Comment.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/entity/Comment.java
@@ -13,6 +13,7 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
@@ -27,6 +28,7 @@ public class Comment {
 
 	private Long memberId;
 
+	@Setter
 	private String content;
 
 	@CreationTimestamp

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/exception/CannotFoundCommentException.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/exception/CannotFoundCommentException.java
@@ -1,0 +1,7 @@
+package kr.co.mathrank.domain.board.exception;
+
+public class CannotFoundCommentException extends PostException {
+	public CannotFoundCommentException() {
+		super(9003, "댓글을 찾을 수 없음");
+	}
+}

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/exception/CannotUpdateCommentException.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/exception/CannotUpdateCommentException.java
@@ -1,0 +1,7 @@
+package kr.co.mathrank.domain.board.exception;
+
+public class CannotUpdateCommentException extends PostException {
+	public CannotUpdateCommentException() {
+		super(9004, "댓글은 본인만 수정할 수 있습니다.");
+	}
+}

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/repository/CommentRepository.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/repository/CommentRepository.java
@@ -1,0 +1,8 @@
+package kr.co.mathrank.domain.board.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.co.mathrank.domain.board.entity.Comment;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/service/CommentUpdateService.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/service/CommentUpdateService.java
@@ -1,0 +1,50 @@
+package kr.co.mathrank.domain.board.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.domain.board.dto.CommentUpdateCommand;
+import kr.co.mathrank.domain.board.entity.Comment;
+import kr.co.mathrank.domain.board.exception.CannotFoundCommentException;
+import kr.co.mathrank.domain.board.exception.CannotUpdateCommentException;
+import kr.co.mathrank.domain.board.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@Validated
+@RequiredArgsConstructor
+public class CommentUpdateService {
+	private final CommentRepository commentRepository;
+
+	/**
+	 * 본인의 댓글만 수정 가능
+	 * @param command
+	 */
+	@Transactional
+	public void update(@NotNull @Valid final CommentUpdateCommand command) {
+		final Comment comment = getComment(command.commentId());
+		if (!isOwner(comment, command.memberId())) {
+			log.info("[CommentUpdateService.update] cannot update comment - commentId: {}, commentOwnerId: {}, requestMemberId: {}",
+				comment.getId(), comment.getMemberId(), command.memberId());
+			throw new CannotUpdateCommentException();
+		}
+		comment.setContent(command.content());
+	}
+
+	private Comment getComment(final Long commentId) {
+		return commentRepository.findById(commentId)
+			.orElseThrow(() -> {
+				log.info("[CommentUpdateService.getComment] cannot found comment - commentId: {}", commentId);
+				return new CannotFoundCommentException();
+			});
+	}
+
+	private boolean isOwner(final Comment comment, final Long requestMemberId) {
+		return comment.getMemberId().equals(requestMemberId);
+	}
+}

--- a/domain/mathrank-board-domain/src/test/java/kr/co/mathrank/domain/board/service/CommentUpdateServiceTest.java
+++ b/domain/mathrank-board-domain/src/test/java/kr/co/mathrank/domain/board/service/CommentUpdateServiceTest.java
@@ -1,0 +1,72 @@
+package kr.co.mathrank.domain.board.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import kr.co.mathrank.domain.board.dto.CommentRegisterCommand;
+import kr.co.mathrank.domain.board.dto.CommentUpdateCommand;
+import kr.co.mathrank.domain.board.entity.Post;
+import kr.co.mathrank.domain.board.exception.CannotFoundCommentException;
+import kr.co.mathrank.domain.board.exception.CannotUpdateCommentException;
+import kr.co.mathrank.domain.board.repository.CommentRepository;
+import kr.co.mathrank.domain.board.repository.PostRepository;
+
+@SpringBootTest
+class CommentUpdateServiceTest {
+	@Autowired
+	private PostRepository postRepository;
+	@Autowired
+	private CommentUpdateService commentUpdateService;
+	@Autowired
+	private CommentRegisterService commentRegisterService;
+	@Autowired
+	private CommentRepository commentRepository;
+
+	@Test
+	void 댓글을_못찾으면_예외() {
+		final Long userId = 1L;
+		final Long postId = postRepository.save(Post.of("title", "content", userId))
+			.getId();
+		final Long commentId = commentRegisterService.register(
+			new CommentRegisterCommand(postId, userId, "testContent"));
+		final Long anotherCommentId = commentId + 1;
+
+		// 다른 commentId로 조회
+		Assertions.assertThrows(CannotFoundCommentException.class, () -> commentUpdateService.update(
+			new CommentUpdateCommand(anotherCommentId, userId, "testContent1")));
+	}
+
+	@Test
+	void 본인_댓글이_아니면_수정_불가() {
+		final Long userId = 1L;
+		final Long anotherUserId = 2L;
+		final Long postId = postRepository.save(Post.of("title", "content", userId))
+			.getId();
+		final Long commentId = commentRegisterService.register(
+			new CommentRegisterCommand(postId, userId, "testContent"));
+
+		// 다른 사용자로 업데이트
+		Assertions.assertThrows(CannotUpdateCommentException.class, () -> commentUpdateService.update(
+			new CommentUpdateCommand(commentId, anotherUserId, "testContent1")));
+	}
+
+	@Test
+	void 본인_댓글_수정은_성공() {
+		final Long userId = 1L;
+		final Long postId = postRepository.save(Post.of("title", "content", userId))
+			.getId();
+
+		final String beforeContent = "beforeContent";
+		final String afterContent = "afterContent";
+
+		final Long commentId = commentRegisterService.register(
+			new CommentRegisterCommand(postId, userId, beforeContent));
+
+		// 정상 업데이트
+		commentUpdateService.update(new CommentUpdateCommand(commentId, userId, afterContent));
+
+		Assertions.assertEquals(afterContent, commentRepository.findById(commentId).get().getContent());
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Users can now edit their own comments.
  - Ownership is enforced: only the original author can update a comment.
  - Clear errors are shown when a comment doesn’t exist or when a non-owner attempts to edit.

- Tests
  - Added integration tests covering successful updates, non-existent comments, and unauthorized edit attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->