### PR TITLE
hotfix(rank): 풀이 기록이 없을 시, null로 인한 500에러 수정

### DIFF
--- a/domain/mathrank-rank-domain/src/main/java/kr/co/mathrank/domain/rank/exception/CannotCalculateRankException.java
+++ b/domain/mathrank-rank-domain/src/main/java/kr/co/mathrank/domain/rank/exception/CannotCalculateRankException.java
@@ -1,0 +1,7 @@
+package kr.co.mathrank.domain.rank.exception;
+
+public class CannotCalculateRankException extends RankException {
+	public CannotCalculateRankException(String message) {
+		super(8003, message);
+	}
+}

--- a/domain/mathrank-rank-domain/src/main/java/kr/co/mathrank/domain/rank/service/RankQueryService.java
+++ b/domain/mathrank-rank-domain/src/main/java/kr/co/mathrank/domain/rank/service/RankQueryService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 
 import kr.co.mathrank.domain.rank.dto.RankQueryResult;
 import kr.co.mathrank.domain.rank.entity.Tier;
+import kr.co.mathrank.domain.rank.exception.CannotCalculateRankException;
 import kr.co.mathrank.domain.rank.repository.RankRepository;
 import kr.co.mathrank.domain.rank.repository.SolverRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,10 +17,16 @@ public class RankQueryService {
 	private final RankRepository rankRepository;
 
 	public RankQueryResult getRank(final Long memberId) {
+		final Long score = rankRepository.getScore(String.valueOf(memberId));
+
+		if (score == null) {
+			log.info("[RankQueryService.getRank] cannot find score - memberId: {}", memberId);
+			throw new CannotCalculateRankException("점수 기록이 없어 랭크를 계산할 수 없습니다.");
+		}
+
 		final long rank = rankRepository.getRank(String.valueOf(memberId));
 		final long totalMemberCount = rankRepository.getTotalRankerCount();
 		final Tier tier = Tier.getMatchTier(rank, totalMemberCount);
-		final Long score = rankRepository.getScore(String.valueOf(memberId));
 
 		return RankQueryResult.of(rank, tier, score, totalMemberCount);
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rank queries now validate score availability upfront and gracefully return an error when a score is missing, preventing failures during calculation.
  * Users receive clearer messaging when a rank cannot be calculated, avoiding confusing or empty results.
  * Improves stability and supportability of ranking features by handling edge cases more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->