### PR TITLE
feat(board): 페이지 조회 쿼리 조건으로 postType 추가

### DIFF
--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/dto/PostPageQuery.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/dto/PostPageQuery.java
@@ -1,9 +1,13 @@
 package kr.co.mathrank.domain.board.dto;
 
+import kr.co.mathrank.domain.board.entity.PostType;
+
 public record PostPageQuery(
 	Long postId,
 	Long memberId,
 	String nickName,
+
+	PostType postType,
 
 	String title,
 

--- a/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/repository/PostQueryRepositoryImpl.java
+++ b/domain/mathrank-board-domain/src/main/java/kr/co/mathrank/domain/board/repository/PostQueryRepositoryImpl.java
@@ -12,6 +12,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import kr.co.mathrank.domain.board.dto.PostPageQuery;
 import kr.co.mathrank.domain.board.entity.Post;
+import kr.co.mathrank.domain.board.entity.PostType;
 import kr.co.mathrank.domain.board.entity.QPost;
 import lombok.RequiredArgsConstructor;
 
@@ -56,8 +57,17 @@ class PostQueryRepositoryImpl implements PostQueryRepository {
 			containsTitle(postQuery.title()),
 			containsMemberNickName(postQuery.nickName()),
 			matchMemberId(postQuery.memberId()),
-			matchSingleProblemId(postQuery.singleProblemId())
+			matchSingleProblemId(postQuery.singleProblemId()),
+			matchPostType(postQuery.postType())
 		};
+	}
+
+	private BooleanExpression matchPostType(final PostType postType) {
+		if (postType == null) {
+			return null;
+		}
+
+		return QPost.post.postType.eq(postType);
 	}
 
 	private BooleanExpression matchSingleProblemId(final Long singleProblemId) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now filter board posts by type (e.g., Q&A, Notice, etc.) when browsing or searching, enabling quicker discovery of relevant content.
  * Post listings respect the selected post type alongside existing filters like nickname and title.

* **Chores**
  * Backend support added to process the new post type filter while keeping existing filters unchanged and compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->