### PR TITLE
feat(assessment)t: 문제집, 대회 이름 수정 API 구성

### DIFF
--- a/app/api/mathrank-problem-assessment-api/src/main/java/kr/co/mathrank/app/api/assessment/AssessmentController.java
+++ b/app/api/mathrank-problem-assessment-api/src/main/java/kr/co/mathrank/app/api/assessment/AssessmentController.java
@@ -1,8 +1,11 @@
 package kr.co.mathrank.app.api.assessment;
 
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,8 +17,10 @@ import kr.co.mathrank.app.api.common.authentication.LoginInfo;
 import kr.co.mathrank.app.api.common.authentication.MemberPrincipal;
 import kr.co.mathrank.common.role.Role;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentRegisterCommand;
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentUpdateCommand;
 import kr.co.mathrank.domain.problem.assessment.dto.SubmissionRegisterCommand;
 import kr.co.mathrank.domain.problem.assessment.service.AssessmentRegisterService;
+import kr.co.mathrank.domain.problem.assessment.service.AssessmentUpdateService;
 import kr.co.mathrank.domain.problem.assessment.service.SubmissionRegisterService;
 import lombok.RequiredArgsConstructor;
 
@@ -25,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 public class AssessmentController {
 	private final AssessmentRegisterService assessmentRegisterService;
 	private final SubmissionRegisterService submissionRegisterService;
+	private final AssessmentUpdateService assessmentUpdateService;
 
 	@Operation(summary = "문제집 등록", description = "문제집 등록은 관리자만 가능합니다.")
 	@PostMapping("/api/v1/problem/assessment")
@@ -49,5 +55,17 @@ public class AssessmentController {
 		final SubmissionRegisterCommand command = request.toCommand(memberPrincipal.memberId());
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(String.valueOf(submissionRegisterService.submit(command)));
+	}
+
+	@Operation(summary = "문제집 수정 API")
+	@PutMapping("/api/v1/problem/assessment/{assessmentId}")
+	@Authorization(values = Role.ADMIN)
+	public ResponseEntity<Void> updateAssessment(
+		@ModelAttribute @ParameterObject @Valid final Requests.AssessmentUpdateRequest request
+	) {
+		final AssessmentUpdateCommand command = request.toCommand();
+		assessmentUpdateService.update(command);
+
+		return ResponseEntity.ok().build();
 	}
 }

--- a/app/api/mathrank-problem-assessment-api/src/main/java/kr/co/mathrank/app/api/assessment/Requests.java
+++ b/app/api/mathrank-problem-assessment-api/src/main/java/kr/co/mathrank/app/api/assessment/Requests.java
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.Size;
 import kr.co.mathrank.common.role.Role;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentItemRegisterCommand;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentRegisterCommand;
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentUpdateCommand;
 import kr.co.mathrank.domain.problem.assessment.dto.SubmissionRegisterCommand;
 
 public class Requests {
@@ -64,6 +65,20 @@ public class Requests {
 		public SubmissionRegisterCommand toCommand(final Long memberId) {
 			return new SubmissionRegisterCommand(memberId, assessmentId, submittedAnswers,
 				Duration.ofSeconds(elapsedTimeSeconds));
+		}
+	}
+
+	record AssessmentUpdateRequest(
+		@NotNull
+		Long assessmentId,
+		@NotBlank
+		String assessmentName
+	) {
+		public AssessmentUpdateCommand toCommand() {
+			return new AssessmentUpdateCommand(
+				assessmentId,
+				assessmentName
+			);
 		}
 	}
 }

--- a/app/api/mathrank-problem-contest-api/src/main/java/kr/co/mathrank/app/api/problem/contest/ContestController.java
+++ b/app/api/mathrank-problem-contest-api/src/main/java/kr/co/mathrank/app/api/problem/contest/ContestController.java
@@ -60,7 +60,7 @@ public class ContestController {
 	@Operation(summary = "대회 수정 API")
 	@PutMapping("/api/v1/problem/contest/{contestId}")
 	@Authorization(values = Role.ADMIN)
-	public ResponseEntity<Void> updateAssessment(
+	public ResponseEntity<Void> updateContest(
 		@ModelAttribute @ParameterObject @Valid final Requests.ContestUpdateRequest request
 	) {
 		final AssessmentUpdateCommand command = request.toCommand();

--- a/app/api/mathrank-problem-contest-api/src/main/java/kr/co/mathrank/app/api/problem/contest/ContestController.java
+++ b/app/api/mathrank-problem-contest-api/src/main/java/kr/co/mathrank/app/api/problem/contest/ContestController.java
@@ -1,8 +1,11 @@
 package kr.co.mathrank.app.api.problem.contest;
 
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,9 +16,11 @@ import kr.co.mathrank.app.api.common.authentication.Authorization;
 import kr.co.mathrank.app.api.common.authentication.LoginInfo;
 import kr.co.mathrank.app.api.common.authentication.MemberPrincipal;
 import kr.co.mathrank.common.role.Role;
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentUpdateCommand;
 import kr.co.mathrank.domain.problem.assessment.dto.LimitedAssessmentRegisterCommand;
 import kr.co.mathrank.domain.problem.assessment.dto.SubmissionRegisterCommand;
 import kr.co.mathrank.domain.problem.assessment.service.AssessmentRegisterService;
+import kr.co.mathrank.domain.problem.assessment.service.AssessmentUpdateService;
 import kr.co.mathrank.domain.problem.assessment.service.SubmissionRegisterService;
 import lombok.RequiredArgsConstructor;
 
@@ -25,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 public class ContestController {
 	private final AssessmentRegisterService assessmentRegisterService;
 	private final SubmissionRegisterService submissionRegisterService;
+	private final AssessmentUpdateService assessmentUpdateService;
 
 	@Operation(summary = "대회 등록", description = "문제집 등록은 관리자만 가능합니다.")
 	@PostMapping("/api/v1/problem/contest")
@@ -49,5 +55,17 @@ public class ContestController {
 		final SubmissionRegisterCommand command = request.toCommand(memberPrincipal.memberId());
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(String.valueOf(submissionRegisterService.submit(command)));
+	}
+
+	@Operation(summary = "대회 수정 API")
+	@PutMapping("/api/v1/problem/contest/{contestId}")
+	@Authorization(values = Role.ADMIN)
+	public ResponseEntity<Void> updateAssessment(
+		@ModelAttribute @ParameterObject @Valid final Requests.ContestUpdateRequest request
+	) {
+		final AssessmentUpdateCommand command = request.toCommand();
+		assessmentUpdateService.update(command);
+
+		return ResponseEntity.ok().build();
 	}
 }

--- a/app/api/mathrank-problem-contest-api/src/main/java/kr/co/mathrank/app/api/problem/contest/Requests.java
+++ b/app/api/mathrank-problem-contest-api/src/main/java/kr/co/mathrank/app/api/problem/contest/Requests.java
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import kr.co.mathrank.common.role.Role;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentItemRegisterCommand;
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentUpdateCommand;
 import kr.co.mathrank.domain.problem.assessment.dto.LimitedAssessmentRegisterCommand;
 import kr.co.mathrank.domain.problem.assessment.dto.SubmissionRegisterCommand;
 
@@ -72,6 +73,20 @@ public class Requests {
 		public SubmissionRegisterCommand toCommand(final Long memberId) {
 			return new SubmissionRegisterCommand(memberId, contestId, submittedAnswers,
 				Duration.ofSeconds(elapsedTimeSeconds));
+		}
+	}
+
+	record ContestUpdateRequest(
+		@NotNull
+		Long contestId,
+		@NotBlank
+		String contestName
+	) {
+		public AssessmentUpdateCommand toCommand() {
+			return new AssessmentUpdateCommand(
+				contestId,
+				contestName
+			);
 		}
 	}
 }

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentUpdateCommand.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentUpdateCommand.java
@@ -1,0 +1,12 @@
+package kr.co.mathrank.domain.problem.assessment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record AssessmentUpdateCommand(
+	@NotNull
+	Long assessmentId,
+	@NotBlank
+	String assessmentName
+) {
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentUpdateService.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentUpdateService.java
@@ -1,0 +1,38 @@
+package kr.co.mathrank.domain.problem.assessment.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentUpdateCommand;
+import kr.co.mathrank.domain.problem.assessment.entity.Assessment;
+import kr.co.mathrank.domain.problem.assessment.exception.NoSuchAssessmentException;
+import kr.co.mathrank.domain.problem.assessment.repository.AssessmentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@Validated
+@RequiredArgsConstructor
+public class AssessmentUpdateService {
+	private final AssessmentRepository assessmentRepository;
+
+	@Transactional
+	public void update(@NotNull @Valid final AssessmentUpdateCommand command) {
+		final Assessment assessment = getAssessment(command.assessmentId());
+		assessment.setAssessmentName(command.assessmentName());
+		log.info("[AssessmentUpdateService.update] updated assessment - assessmentId: {}", assessment.getId());
+	}
+
+	private Assessment getAssessment(final Long assessmentId) {
+		return assessmentRepository.findById(assessmentId)
+			.orElseThrow(() -> {
+				log.info("[AssessmentUpdateService.getAssessment] cannot found assessment - assessmentId: {}",
+					assessmentId);
+				return new NoSuchAssessmentException();
+			});
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin-only APIs to update assessments and contests (PUT endpoints).
  * Supports renaming by providing ID and new name.
  * Requests validated; return 200 on success, 404 if not found, 400 on invalid input.
* **Chores**
  * Added a backend service to perform and log assessment/contest updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->