### PR TITLE
hotfix(board): id 타입을 long -> string 으로 수정

### DIFF
--- a/app/api/mathrank-board-api/src/main/java/kr/co/mathrank/app/api/board/BoardController.java
+++ b/app/api/mathrank-board-api/src/main/java/kr/co/mathrank/app/api/board/BoardController.java
@@ -71,10 +71,11 @@ public class BoardController {
 	@PutMapping("/api/v1/board/post/{postId}")
 	@Authorization(openedForAll = true)
 	public ResponseEntity<Void> update(
+		@PathVariable final Long postId,
 		@ModelAttribute @ParameterObject @Valid final Requests.PostUpdateRequest request,
 		@LoginInfo final MemberPrincipal memberPrincipal
 	) {
-		final PostUpdateCommand command = request.toCommand(memberPrincipal.memberId());
+		final PostUpdateCommand command = request.toCommand(postId, memberPrincipal.memberId());
 		postUpdateService.update(command);
 
 		return ResponseEntity.ok().build();
@@ -125,10 +126,11 @@ public class BoardController {
 	@Authorization(openedForAll = true)
 	@PostMapping("/api/v1/board/post/{postId}/comment")
 	public ResponseEntity<String> postComment(
+		@PathVariable final Long postId,
 		@ModelAttribute @ParameterObject @Valid final Requests.CommentSaveRequest request,
 		@LoginInfo final MemberPrincipal memberPrincipal
 	) {
-		final CommentRegisterCommand command = request.toCommand(memberPrincipal.memberId());
+		final CommentRegisterCommand command = request.toCommand(postId, memberPrincipal.memberId());
 		final Long commentId = commentRegisterService.register(command);
 
 		return ResponseEntity.ok(String.valueOf(commentId));

--- a/app/api/mathrank-board-api/src/main/java/kr/co/mathrank/app/api/board/BoardController.java
+++ b/app/api/mathrank-board-api/src/main/java/kr/co/mathrank/app/api/board/BoardController.java
@@ -57,14 +57,14 @@ public class BoardController {
 	@Operation(summary = "게시글 등록 API")
 	@PostMapping("/api/v1/board/post")
 	@Authorization(openedForAll = true)
-	public ResponseEntity<Long> save(
+	public ResponseEntity<String> save(
 		@ModelAttribute @ParameterObject @Valid final Requests.PostSaveRequest request,
 		@LoginInfo final MemberPrincipal memberPrincipal
 	) {
 		final PostRegisterCommand command = request.toCommand(memberPrincipal.memberId(), memberPrincipal.role());
 		final Long postId = postRegisterService.register(command);
 
-		return ResponseEntity.ok(postId);
+		return ResponseEntity.ok(String.valueOf(postId));
 	}
 
 	@Operation(summary = "게시글 수정 API")
@@ -95,12 +95,13 @@ public class BoardController {
 
 	@Operation(summary = "페이지 조회 API", description = "정렬은 날짜 내림차순으로 적용됩니다.")
 	@GetMapping("/api/v1/board/post")
-	public ResponseEntity<PageResult<PostPageQueryResult>> pageQuery(
+	public ResponseEntity<PageResult<Responses.PostPageQueryResponse>> pageQuery(
 		@RequestParam(defaultValue = "1") @Range(min = 1, max = 1000) final Integer pageNumber,
 		@RequestParam(defaultValue = "20") @Range(min = 1, max = 20) final Integer pageSize,
 		@ModelAttribute @ParameterObject final PostPageQuery query
 	) {
-		return ResponseEntity.ok(postQueryService.pageQuery(query, pageSize, pageNumber));
+		return ResponseEntity.ok(postQueryService.pageQuery(query, pageSize, pageNumber)
+			.map(Responses.PostPageQueryResponse::from));
 	}
 
 	@Operation(summary = "게시글 상세 조회 API")
@@ -123,14 +124,14 @@ public class BoardController {
 	@Operation(summary = "댓글 작성 API")
 	@Authorization(openedForAll = true)
 	@PostMapping("/api/v1/board/post/{postId}/comment")
-	public ResponseEntity<Long> postComment(
+	public ResponseEntity<String> postComment(
 		@ModelAttribute @ParameterObject @Valid final Requests.CommentSaveRequest request,
 		@LoginInfo final MemberPrincipal memberPrincipal
 	) {
 		final CommentRegisterCommand command = request.toCommand(memberPrincipal.memberId());
 		final Long commentId = commentRegisterService.register(command);
 
-		return ResponseEntity.ok(commentId);
+		return ResponseEntity.ok(String.valueOf(commentId));
 	}
 
 	@Operation(summary = "댓글 수정 API", description = "본인이 작성한 댓글만 수정 가능. 관리자도 수정 불가")

--- a/app/api/mathrank-board-api/src/main/java/kr/co/mathrank/app/api/board/Requests.java
+++ b/app/api/mathrank-board-api/src/main/java/kr/co/mathrank/app/api/board/Requests.java
@@ -52,25 +52,21 @@ public class Requests {
 	}
 
 	record PostUpdateRequest(
-		@NotNull
-		Long postId,
 		@NotEmpty
 		String title,
 		@NotEmpty
 		String content
 	) {
-		public PostUpdateCommand toCommand(final Long memberId) {
+		public PostUpdateCommand toCommand(final Long postId, final Long memberId) {
 			return new PostUpdateCommand(postId, memberId, title, content);
 		}
 	}
 
 	record CommentSaveRequest(
 		@NotNull
-		Long postId,
-		@NotNull
 		String content
 	) {
-		public CommentRegisterCommand toCommand(final Long memberId) {
+		public CommentRegisterCommand toCommand(final Long postId, final Long memberId) {
 			return new CommentRegisterCommand(
 				postId,
 				memberId,

--- a/app/api/mathrank-board-api/src/main/java/kr/co/mathrank/app/api/board/Responses.java
+++ b/app/api/mathrank-board-api/src/main/java/kr/co/mathrank/app/api/board/Responses.java
@@ -6,46 +6,47 @@ import java.util.List;
 import kr.co.mathrank.client.internal.member.MemberInfo;
 import kr.co.mathrank.domain.board.dto.CommentDetailResult;
 import kr.co.mathrank.domain.board.dto.PostDetailQueryResult;
+import kr.co.mathrank.domain.board.dto.PostPageQueryResult;
 import kr.co.mathrank.domain.board.entity.PostType;
 
 public class Responses {
 	record PostDetailResponse(
-		Long postId,
+		String postId,
 		MemberResponse memberInfo,
 		PostType postType,
 		String title,
 		String content,
 		List<CommentDetailResponse> comments,
-		Long singleProblemId,
-		Long assessmentId,
-		Long contestId,
+		String singleProblemId,
+		String assessmentId,
+		String contestId,
 		LocalDateTime createdAt
 	) {
 		public static PostDetailResponse from(final PostDetailQueryResult postResult, final List<CommentDetailResponse> comments) {
 			return new PostDetailResponse(
-				postResult.postId(),
+				String.valueOf(postResult.postId()),
 				MemberResponse.from(postResult.memberId(), postResult.memberNickName()),
 				postResult.postType(),
 				postResult.title(),
 				postResult.content(),
 				comments,
-				postResult.singleProblemId(),
-				postResult.assessmentId(),
-				postResult.contestId(),
+				String.valueOf(postResult.singleProblemId()),
+				String.valueOf(postResult.assessmentId()),
+				String.valueOf(postResult.contestId()),
 				postResult.createdAt()
 			);
 		}
 	}
 
 	record CommentDetailResponse(
-		Long commentId,
+		String commentId,
 		MemberResponse memberInfo,
 		String content,
 		LocalDateTime createdAt
 	) {
 		public static CommentDetailResponse from(final CommentDetailResult commentDetailResult, final MemberInfo memberInfo) {
 			return new CommentDetailResponse(
-				commentDetailResult.commentId(),
+				String.valueOf(commentDetailResult.commentId()),
 				MemberResponse.from(memberInfo),
 				commentDetailResult.content(),
 				commentDetailResult.createdAt()
@@ -54,12 +55,12 @@ public class Responses {
 	}
 
 	record MemberResponse(
-		Long memberId,
+		String memberId,
 		String nickName
 	) {
 		public static MemberResponse from(final MemberInfo memberInfo) {
 			return new MemberResponse(
-				memberInfo.memberId(),
+				String.valueOf(memberInfo.memberId()),
 				memberInfo.memberName()
 			);
 		}
@@ -67,8 +68,40 @@ public class Responses {
 		// Post의 경우, 닉네임 기반 조회라 client를 통한 닉네임 조회 필요 없음
 		public static MemberResponse from(final Long memberId, final String nickName) {
 			return new MemberResponse(
-				memberId,
+				String.valueOf(memberId),
 				nickName
+			);
+		}
+	}
+
+	record PostPageQueryResponse(
+		String postId,
+		String memberId,
+		String memberNickName,
+		PostType postType,
+
+		String title,
+
+		String singleProblemId,
+		String assessmentId,
+		String contestId,
+
+		Integer commentCount,
+
+		LocalDateTime createdAt
+	) {
+		public static PostPageQueryResponse from(final PostPageQueryResult result) {
+			return new PostPageQueryResponse(
+				String.valueOf(result.postId()),
+				String.valueOf(result.memberId()),
+				result.memberNickName(),
+				result.postType(),
+				result.title(),
+				String.valueOf(result.singleProblemId()),
+				String.valueOf(result.assessmentId()),
+				String.valueOf(result.contestId()),
+				result.commentCount(),
+				result.createdAt()
 			);
 		}
 	}


### PR DESCRIPTION
- 프론트에서 string 으로 받고 있으므로, 하위 코드 리뷰가 제시하는 것들은 문제가 안됨


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a standardized paginated post list response with richer fields for listing posts.

- Refactor
  - All IDs in responses are now strings for consistency.
  - Save and comment creation endpoints now return string IDs.
  - Update and comment creation endpoints require postId in the URL path.
  - Request bodies for post update and comment creation no longer include postId.
  - Paginated posts endpoint returns an updated response schema with mapped fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->