### PR TITLE
docs: api 문서 수정

### DIFF
--- a/.github/workflows/code-deploy.yml
+++ b/.github/workflows/code-deploy.yml
@@ -38,6 +38,14 @@ jobs:
           role-to-assume: arn:aws:iam::688567299537:role/mathrank-git-action-s3
           aws-region: ap-northeast-2
 
+      - name: Save Git tag to SSM
+        run: |
+          aws ssm put-parameter \
+            --name "/mathrank/aws/monolith/server.version" \
+            --type "String" \
+            --value "${GITHUB_REF_NAME}" \
+            --overwrite
+
       - name: Upload to S3
         run: aws s3 cp release-${GITHUB_SHA}.zip s3://mathrank-mono-jar/releases/
 

--- a/app/api/mathrank-api-common/src/main/java/kr/co/mathrank/app/api/common/docs/CommonOpenApiConfiguration.java
+++ b/app/api/mathrank-api-common/src/main/java/kr/co/mathrank/app/api/common/docs/CommonOpenApiConfiguration.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Configuration;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
@@ -19,10 +20,16 @@ public class CommonOpenApiConfiguration {
 	private static final String SECURITY_SCHEME_NAME = "JWT";
 	@Value("${server.url}")
 	private String url;
+	@Value("${server.version}")
+	private String tagVersion;
 
 	@Bean
 	public OpenAPI addSecurityComponent() {
 		return new OpenAPI()
+			.info(new Info()
+				.title("매쓰랭 API")
+				.version(tagVersion) // 여기서 버전 변경
+				.description("API 문서 설명"))
 			.components(new Components().addSecuritySchemes(SECURITY_SCHEME_NAME,
 				new SecurityScheme()
 					.type(SecurityScheme.Type.HTTP)

--- a/app/api/mathrank-api-common/src/main/java/kr/co/mathrank/app/api/common/docs/CommonOpenApiConfiguration.java
+++ b/app/api/mathrank-api-common/src/main/java/kr/co/mathrank/app/api/common/docs/CommonOpenApiConfiguration.java
@@ -18,9 +18,9 @@ import kr.co.mathrank.app.api.common.authentication.Authorization;
 @Configuration
 public class CommonOpenApiConfiguration {
 	private static final String SECURITY_SCHEME_NAME = "JWT";
-	@Value("${server.url}")
+	@Value("${server.url:http://localhost}")
 	private String url;
-	@Value("${server.version}")
+	@Value("${server.version:test}")
 	private String tagVersion;
 
 	@Bean

--- a/app/api/mathrank-api-common/src/main/java/kr/co/mathrank/app/api/common/docs/CommonOpenApiConfiguration.java
+++ b/app/api/mathrank-api-common/src/main/java/kr/co/mathrank/app/api/common/docs/CommonOpenApiConfiguration.java
@@ -2,6 +2,8 @@ package kr.co.mathrank.app.api.common.docs;
 
 import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -15,6 +17,8 @@ import kr.co.mathrank.app.api.common.authentication.Authorization;
 @Configuration
 public class CommonOpenApiConfiguration {
 	private static final String SECURITY_SCHEME_NAME = "JWT";
+	@Value("${server.url}")
+	private String url;
 
 	@Bean
 	public OpenAPI addSecurityComponent() {
@@ -47,7 +51,7 @@ public class CommonOpenApiConfiguration {
 	@Bean
 	public OpenApiCustomizer addDeployUrl() {
 		return openAPIBuilder -> {
-			openAPIBuilder.addServersItem(new Server().url("https://rank.hpmath.co.kr"));
+			openAPIBuilder.addServersItem(new Server().url(url));
 		};
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * API docs now use an environment-configured server URL, show the deployed version and description, and include JWT bearer authentication details for clearer auth guidance.
* **Chores**
  * CI workflow saves the current Git tag/version to AWS SSM before upload, ensuring deployment tooling can reference the release version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->