### PR TITLE
feat(member): 계정 삭제 구현

### DIFF
--- a/app/api/mathrank-member-api/src/main/java/kr/co/mathrank/app/api/member/MemberController.java
+++ b/app/api/mathrank-member-api/src/main/java/kr/co/mathrank/app/api/member/MemberController.java
@@ -1,6 +1,8 @@
 package kr.co.mathrank.app.api.member;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -10,7 +12,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.mathrank.app.api.common.authentication.Authorization;
 import kr.co.mathrank.app.api.common.authentication.LoginInfo;
 import kr.co.mathrank.app.api.common.authentication.MemberPrincipal;
+import kr.co.mathrank.domain.auth.dto.MemberDeleteCommand;
 import kr.co.mathrank.domain.auth.dto.MemberUpdateCommand;
+import kr.co.mathrank.domain.auth.service.MemberDeleteService;
 import kr.co.mathrank.domain.auth.service.MemberUpdateService;
 import lombok.RequiredArgsConstructor;
 
@@ -19,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MemberController {
 	private final MemberUpdateService memberUpdateService;
+	private final MemberDeleteService memberDeleteService;
 
 	@PutMapping("/api/v1/member/info/my")
 	@Operation(summary = "내 계정 정보 업데이트 API", description = "내 계정의 정보를 주어진 페이로드로 업데이트 합니다.")
@@ -30,6 +35,19 @@ public class MemberController {
 		final MemberUpdateCommand command = request.toCommand(memberPrincipal.memberId());
 		memberUpdateService.update(command);
 
+		return ResponseEntity.ok().build();
+	}
+
+	@DeleteMapping("/api/v1/member/{memberId}")
+	@Operation(summary = "계정 삭제 API", description = "본인 계정만 삭제 가능합니다. ADMIN 은 모두 삭제 가능합니다.")
+	@Authorization(openedForAll = true)
+	public ResponseEntity<Void> delete(
+		@PathVariable final Long memberId,
+		@LoginInfo final MemberPrincipal memberPrincipal
+	) {
+		final MemberDeleteCommand command = new MemberDeleteCommand(memberId, memberPrincipal.memberId(),
+			memberPrincipal.role());
+		memberDeleteService.delete(command);
 		return ResponseEntity.ok().build();
 	}
 }

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/dto/MemberDeleteCommand.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/dto/MemberDeleteCommand.java
@@ -1,0 +1,23 @@
+package kr.co.mathrank.domain.auth.dto;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.common.role.Role;
+
+public record MemberDeleteCommand(
+	@NotNull
+	Long targetMemberId,
+	@NotNull
+	Long requestMemberId,
+	@NotNull
+	Role role
+) {
+	@AssertTrue(message = "본인 계정만 삭제할 수 있습니다.")
+	public boolean isValid() {
+		if (targetMemberId == null || requestMemberId == null) {
+			return true;
+		}
+
+		return requestMemberId.equals(targetMemberId) || role == Role.ADMIN;
+	}
+}

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/service/MemberDeleteService.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/service/MemberDeleteService.java
@@ -1,0 +1,35 @@
+package kr.co.mathrank.domain.auth.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.domain.auth.dto.MemberDeleteCommand;
+import kr.co.mathrank.domain.auth.entity.Member;
+import kr.co.mathrank.domain.auth.exception.CannotFoundMemberException;
+import kr.co.mathrank.domain.auth.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@Validated
+@RequiredArgsConstructor
+public class MemberDeleteService {
+	private final MemberRepository memberRepository;
+
+	public void delete(@NotNull @Valid final MemberDeleteCommand command) {
+		final Member member = getMember(command.targetMemberId());
+		memberRepository.delete(member);
+		log.info("[MemberDeleteService.delete] member delete success - memberId: {}", command.targetMemberId());
+	}
+
+	private Member getMember(final Long targetMemberId) {
+		return memberRepository.findById(targetMemberId)
+			.orElseThrow(() -> {
+				log.info("[MemberDeleteService.getMember] cannot found member - memberId: {}", targetMemberId);
+				return new CannotFoundMemberException();
+			});
+	}
+}

--- a/domain/mathrank-auth-domain/src/test/java/kr/co/mathrank/domain/auth/service/MemberDeleteServiceTest.java
+++ b/domain/mathrank-auth-domain/src/test/java/kr/co/mathrank/domain/auth/service/MemberDeleteServiceTest.java
@@ -1,0 +1,50 @@
+package kr.co.mathrank.domain.auth.service;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.validation.ConstraintViolationException;
+import kr.co.mathrank.common.role.Role;
+import kr.co.mathrank.domain.auth.dto.MemberDeleteCommand;
+import kr.co.mathrank.domain.auth.entity.Member;
+import kr.co.mathrank.domain.auth.entity.MemberType;
+import kr.co.mathrank.domain.auth.repository.MemberRepository;
+
+@SpringBootTest
+@Transactional
+class MemberDeleteServiceTest {
+	@Autowired
+	private MemberDeleteService deleteService;
+	@MockitoBean
+	private MemberRepository memberRepository;
+
+	@Test
+	void 삭제_대상_아이디와_요청_아이디가_다르면_예외() {
+		Mockito.when(memberRepository.findById(Mockito.anyLong())).thenReturn(Optional.of(createMember()));
+		Assertions.assertThrows(ConstraintViolationException.class,
+			() -> deleteService.delete(new MemberDeleteCommand(1L, 2L, Role.USER)));
+	}
+
+	@Test
+	void 본인_아이디_삭제면_가능() {
+		Mockito.when(memberRepository.findById(Mockito.anyLong())).thenReturn(Optional.of(createMember()));
+		Assertions.assertDoesNotThrow(() -> deleteService.delete(new MemberDeleteCommand(1L, 1L, Role.USER)));
+	}
+
+	@Test
+	void 어드민이면_다른_아이디_삭제_가능() {
+		Mockito.when(memberRepository.findById(Mockito.anyLong())).thenReturn(Optional.of(createMember()));
+		Assertions.assertDoesNotThrow(() -> deleteService.delete(new MemberDeleteCommand(1L, 2L, Role.ADMIN)));
+	}
+
+	private Member createMember() {
+		return Member.of(1L, "test", Role.USER, "1L", "test", MemberType.NORMAL, true, "2321");
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added member account deletion endpoint (DELETE /api/v1/member/{memberId}). Only the account owner or an admin can delete. Returns 200 OK on success.
- Documentation
  - Documented the new deletion endpoint in API/Swagger.
- Tests
  - Added unit tests for self-deletion, admin-initiated deletion, and invalid requester scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->