### PR TITLE
feat(assessment): 문제집 삭제 구현

### DIFF
--- a/app/api/mathrank-problem-assessment-api/src/main/java/kr/co/mathrank/app/api/assessment/AssessmentController.java
+++ b/app/api/mathrank-problem-assessment-api/src/main/java/kr/co/mathrank/app/api/assessment/AssessmentController.java
@@ -3,7 +3,9 @@ package kr.co.mathrank.app.api.assessment;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,9 +18,11 @@ import kr.co.mathrank.app.api.common.authentication.Authorization;
 import kr.co.mathrank.app.api.common.authentication.LoginInfo;
 import kr.co.mathrank.app.api.common.authentication.MemberPrincipal;
 import kr.co.mathrank.common.role.Role;
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentDeleteCommand;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentRegisterCommand;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentUpdateCommand;
 import kr.co.mathrank.domain.problem.assessment.dto.SubmissionRegisterCommand;
+import kr.co.mathrank.domain.problem.assessment.service.AssessmentDeleteService;
 import kr.co.mathrank.domain.problem.assessment.service.AssessmentRegisterService;
 import kr.co.mathrank.domain.problem.assessment.service.AssessmentUpdateService;
 import kr.co.mathrank.domain.problem.assessment.service.SubmissionRegisterService;
@@ -31,6 +35,7 @@ public class AssessmentController {
 	private final AssessmentRegisterService assessmentRegisterService;
 	private final SubmissionRegisterService submissionRegisterService;
 	private final AssessmentUpdateService assessmentUpdateService;
+	private final AssessmentDeleteService assessmentDeleteService;
 
 	@Operation(summary = "문제집 등록", description = "문제집 등록은 관리자만 가능합니다.")
 	@PostMapping("/api/v1/problem/assessment")
@@ -66,6 +71,18 @@ public class AssessmentController {
 		final AssessmentUpdateCommand command = request.toCommand();
 		assessmentUpdateService.update(command);
 
+		return ResponseEntity.ok().build();
+	}
+
+	@Operation(summary = "문제집 삭제 API")
+	@DeleteMapping("/api/v1/problem/assessment/{assessmentId}")
+	@Authorization(openedForAll = true)
+	public ResponseEntity<Void> delete(
+		@PathVariable final Long assessmentId,
+		@LoginInfo final MemberPrincipal memberPrincipal
+	) {
+		final AssessmentDeleteCommand command = new AssessmentDeleteCommand(assessmentId, memberPrincipal.memberId(), memberPrincipal.role());
+		assessmentDeleteService.delete(command);
 		return ResponseEntity.ok().build();
 	}
 }

--- a/app/api/mathrank-problem-contest-api/src/main/java/kr/co/mathrank/app/api/problem/contest/ContestController.java
+++ b/app/api/mathrank-problem-contest-api/src/main/java/kr/co/mathrank/app/api/problem/contest/ContestController.java
@@ -3,7 +3,9 @@ package kr.co.mathrank.app.api.problem.contest;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,9 +18,11 @@ import kr.co.mathrank.app.api.common.authentication.Authorization;
 import kr.co.mathrank.app.api.common.authentication.LoginInfo;
 import kr.co.mathrank.app.api.common.authentication.MemberPrincipal;
 import kr.co.mathrank.common.role.Role;
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentDeleteCommand;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentUpdateCommand;
 import kr.co.mathrank.domain.problem.assessment.dto.LimitedAssessmentRegisterCommand;
 import kr.co.mathrank.domain.problem.assessment.dto.SubmissionRegisterCommand;
+import kr.co.mathrank.domain.problem.assessment.service.AssessmentDeleteService;
 import kr.co.mathrank.domain.problem.assessment.service.AssessmentRegisterService;
 import kr.co.mathrank.domain.problem.assessment.service.AssessmentUpdateService;
 import kr.co.mathrank.domain.problem.assessment.service.SubmissionRegisterService;
@@ -31,6 +35,7 @@ public class ContestController {
 	private final AssessmentRegisterService assessmentRegisterService;
 	private final SubmissionRegisterService submissionRegisterService;
 	private final AssessmentUpdateService assessmentUpdateService;
+	private final AssessmentDeleteService assessmentDeleteService;
 
 	@Operation(summary = "대회 등록", description = "문제집 등록은 관리자만 가능합니다.")
 	@PostMapping("/api/v1/problem/contest")
@@ -66,6 +71,18 @@ public class ContestController {
 		final AssessmentUpdateCommand command = request.toCommand();
 		assessmentUpdateService.update(command);
 
+		return ResponseEntity.ok().build();
+	}
+
+	@Operation(summary = "대회 삭제 API")
+	@DeleteMapping("/api/v1/problem/contest/{contestId}")
+	@Authorization(openedForAll = true)
+	public ResponseEntity<Void> delete(
+		@PathVariable final Long contestId,
+		@LoginInfo final MemberPrincipal memberPrincipal
+	) {
+		final AssessmentDeleteCommand command = new AssessmentDeleteCommand(contestId, memberPrincipal.memberId(), memberPrincipal.role());
+		assessmentDeleteService.delete(command);
 		return ResponseEntity.ok().build();
 	}
 }

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentDeleteCommand.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentDeleteCommand.java
@@ -1,0 +1,14 @@
+package kr.co.mathrank.domain.problem.assessment.dto;
+
+import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.common.role.Role;
+
+public record AssessmentDeleteCommand(
+	@NotNull
+	Long assessmentId,
+	@NotNull
+	Long requestMemberId,
+	@NotNull
+	Role requestMemberRole
+) {
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/exception/CannotDeleteAssessmentException.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/exception/CannotDeleteAssessmentException.java
@@ -1,0 +1,7 @@
+package kr.co.mathrank.domain.problem.assessment.exception;
+
+public class CannotDeleteAssessmentException extends AssessmentException {
+	public CannotDeleteAssessmentException() {
+		super(7011, "삭제할 수 없습니다.");
+	}
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentDeleteService.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentDeleteService.java
@@ -1,0 +1,53 @@
+package kr.co.mathrank.domain.problem.assessment.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.common.role.Role;
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentDeleteCommand;
+import kr.co.mathrank.domain.problem.assessment.entity.Assessment;
+import kr.co.mathrank.domain.problem.assessment.exception.AssessmentException;
+import kr.co.mathrank.domain.problem.assessment.exception.CannotDeleteAssessmentException;
+import kr.co.mathrank.domain.problem.assessment.exception.NoSuchAssessmentException;
+import kr.co.mathrank.domain.problem.assessment.repository.AssessmentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Validated
+public class AssessmentDeleteService {
+	private final AssessmentRepository assessmentRepository;
+
+	@Transactional
+	public void delete(@NotNull @Valid final AssessmentDeleteCommand command) {
+		final Assessment assessment = getAssessment(command);
+		validateOwner(assessment, command.requestMemberId(), command.requestMemberRole());
+		assessmentRepository.delete(assessment);
+	}
+
+	private Assessment getAssessment(AssessmentDeleteCommand command) {
+		return assessmentRepository.findById(command.assessmentId())
+			.orElseThrow(() -> {
+				log.info("[AssessmentDeleteService.getAssessment] cannot found assessment - assessmentId: {}",
+					command.assessmentId());
+				return new NoSuchAssessmentException();
+			});
+	}
+
+	private void validateOwner(final Assessment assessment, final Long requestMemberId, final Role requestMemberRole) {
+		if (requestMemberRole == Role.ADMIN) {
+			return;
+		}
+
+		if (assessment.getRegisterMemberId().equals(requestMemberId)) {
+			return;
+		}
+
+		throw new CannotDeleteAssessmentException();
+	}
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentDeleteService.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentDeleteService.java
@@ -25,16 +25,16 @@ public class AssessmentDeleteService {
 
 	@Transactional
 	public void delete(@NotNull @Valid final AssessmentDeleteCommand command) {
-		final Assessment assessment = getAssessment(command);
+		final Assessment assessment = getAssessment(command.assessmentId());
 		validateOwner(assessment, command.requestMemberId(), command.requestMemberRole());
 		assessmentRepository.delete(assessment);
 	}
 
-	private Assessment getAssessment(AssessmentDeleteCommand command) {
-		return assessmentRepository.findById(command.assessmentId())
+	private Assessment getAssessment(final Long assessmentId) {
+		return assessmentRepository.findById(assessmentId)
 			.orElseThrow(() -> {
 				log.info("[AssessmentDeleteService.getAssessment] cannot found assessment - assessmentId: {}",
-					command.assessmentId());
+					assessmentId);
 				return new NoSuchAssessmentException();
 			});
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added ability to delete problem assessments (owners and admins); deletions apply immediately.
  - Added ability to delete contests with the same owner/admin permission rules.
  - Deletion operations now return clear, consistent error responses when not allowed or when the item does not exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->