### PR TITLE
fix(assessment): 정답 조회 시, lazy loading으로 인한 서버에러 수정

### DIFF
--- a/app/api/mathrank-problem-assessment-api/src/main/java/kr/co/mathrank/app/api/assessment/AssessmentController.java
+++ b/app/api/mathrank-problem-assessment-api/src/main/java/kr/co/mathrank/app/api/assessment/AssessmentController.java
@@ -99,7 +99,7 @@ public class AssessmentController {
 		@PathVariable final Long assessmentId,
 		@LoginInfo final MemberPrincipal memberPrincipal
 	) {
-		final AssessmentSolutionQuery query = new AssessmentSolutionQuery(assessmentId, memberPrincipal.memberId());
+		final AssessmentSolutionQuery query = new AssessmentSolutionQuery(assessmentId, memberPrincipal.memberId(), memberPrincipal.role());
 		final AssessmentSolutionQueryResult result = assessmentSolutionQueryService.querySolutions(query);
 		return ResponseEntity.ok(result);
 	}

--- a/app/api/mathrank-problem-contest-api/src/main/java/kr/co/mathrank/app/api/problem/contest/ContestController.java
+++ b/app/api/mathrank-problem-contest-api/src/main/java/kr/co/mathrank/app/api/problem/contest/ContestController.java
@@ -98,7 +98,7 @@ public class ContestController {
 		@PathVariable final Long contestId,
 		@LoginInfo final MemberPrincipal memberPrincipal
 	) {
-		final AssessmentSolutionQuery query = new AssessmentSolutionQuery(contestId, memberPrincipal.memberId());
+		final AssessmentSolutionQuery query = new AssessmentSolutionQuery(contestId, memberPrincipal.memberId(), memberPrincipal.role());
 		final AssessmentSolutionQueryResult result = assessmentSolutionQueryService.querySolutions(query);
 		return ResponseEntity.ok(result);
 	}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentSolutionQuery.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentSolutionQuery.java
@@ -1,11 +1,14 @@
 package kr.co.mathrank.domain.problem.assessment.dto;
 
 import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.common.role.Role;
 
 public record AssessmentSolutionQuery(
 	@NotNull
 	Long assessmentId,
 	@NotNull
-	Long requestMemberId
+	Long requestMemberId,
+	@NotNull
+	Role requestMemberRole
 ) {
 }

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentSolutionQueryService.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentSolutionQueryService.java
@@ -50,15 +50,17 @@ public class AssessmentSolutionQueryService {
 	}
 
 	private Assessment getSubmittedAssessment(final Long assessmentId, final Long requestMemberId, final Role role) {
-		return assessmentRepository.findWithSubmissions(assessmentId).stream()
-			.peek(assessment -> validatePermission(assessment, requestMemberId, role))
-			.findAny()
+		final Assessment assessment = assessmentRepository.findWithSubmissions(assessmentId)
 			.orElseThrow(() -> {
 				log.info(
 					"[AssessmentSolutionQueryService.getSubmittedAssessment] assessment not solved - assessmentId: {}, requestMemberId: {}",
 					assessmentId, requestMemberId);
 				return new NoSuchSubmissionException();
 			});
+
+		validatePermission(assessment, requestMemberId, role);
+
+		return assessment;
 	}
 
 	private void validatePermission(final Assessment assessment, final Long requestMemberId, final Role role) {

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentSolutionQueryService.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentSolutionQueryService.java
@@ -3,6 +3,7 @@ package kr.co.mathrank.domain.problem.assessment.service;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
 import jakarta.validation.Valid;
@@ -31,6 +32,7 @@ public class AssessmentSolutionQueryService {
 	 * 사용자가 문제를 푼 경우에만 정답 조회가 가능합니다.
 	 * @param query
 	 */
+	@Transactional(readOnly = true)
 	public AssessmentSolutionQueryResult querySolutions(@NotNull @Valid final AssessmentSolutionQuery query) {
 		final Assessment solvedAssessment = getSubmittedAssessment(query.assessmentId(), query.requestMemberId(), query.requestMemberRole());
 

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentSolutionQueryService.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentSolutionQueryService.java
@@ -7,13 +7,14 @@ import org.springframework.validation.annotation.Validated;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import kr.co.mathrank.client.internal.problem.ProblemQueryResult;
+import kr.co.mathrank.common.role.Role;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentSolutionQuery;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentSolutionQueryResult;
 import kr.co.mathrank.domain.problem.assessment.dto.ProblemSolutionResult;
 import kr.co.mathrank.domain.problem.assessment.entity.Assessment;
 import kr.co.mathrank.domain.problem.assessment.entity.AssessmentItem;
 import kr.co.mathrank.domain.problem.assessment.exception.CannotGetSolutionException;
+import kr.co.mathrank.domain.problem.assessment.exception.NoSuchSubmissionException;
 import kr.co.mathrank.domain.problem.assessment.repository.AssessmentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,7 +32,7 @@ public class AssessmentSolutionQueryService {
 	 * @param query
 	 */
 	public AssessmentSolutionQueryResult querySolutions(@NotNull @Valid final AssessmentSolutionQuery query) {
-		final Assessment solvedAssessment = getSubmittedAssessment(query.assessmentId(), query.requestMemberId());
+		final Assessment solvedAssessment = getSubmittedAssessment(query.assessmentId(), query.requestMemberId(), query.requestMemberRole());
 
 		final List<ProblemSolutionResult> results = solvedAssessment.getAssessmentItems().stream()
 			.map(AssessmentItem::getProblemId)
@@ -42,13 +43,33 @@ public class AssessmentSolutionQueryService {
 		return new AssessmentSolutionQueryResult(results);
 	}
 
-	private Assessment getSubmittedAssessment(final Long assessmentId, final Long requestMemberId) {
-		return assessmentRepository.findByAssessmentIdAndSubmissionMemberId(assessmentId, requestMemberId)
+	private Assessment getSubmittedAssessment(final Long assessmentId, final Long requestMemberId, final Role role) {
+		return assessmentRepository.findWithSubmissions(assessmentId).stream()
+			.peek(assessment -> validatePermission(assessment, requestMemberId, role))
+			.findAny()
 			.orElseThrow(() -> {
 				log.info(
-					"[AssessmentSolutionQueryService.querySolutions] assessment not solved - assessmentId: {}, requestMemberId: {}",
+					"[AssessmentSolutionQueryService.getSubmittedAssessment] assessment not solved - assessmentId: {}, requestMemberId: {}",
 					assessmentId, requestMemberId);
-				return new CannotGetSolutionException();
+				return new NoSuchSubmissionException();
 			});
+	}
+
+	private void validatePermission(final Assessment assessment, final Long requestMemberId, final Role role) {
+		// 관리자면 pass
+		if (role == Role.ADMIN) {
+			return;
+		}
+
+		// 풀이기록이 있을때 통과
+		if (assessment.getAssessmentSubmissions().stream()
+			.anyMatch(assessmentSubmission -> assessmentSubmission.getMemberId().equals(requestMemberId))) {
+			return;
+		}
+
+		log.info(
+			"[AssessmentSolutionQueryService.validatePermission] cannot access assessment solution - assessmentId: {}, requestMemberId: {}, requestMemberRole: {}",
+			assessment.getId(), requestMemberId, role);
+		throw new CannotGetSolutionException();
 	}
 }

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentSolutionQueryService.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentSolutionQueryService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.validation.annotation.Validated;
 
 import jakarta.validation.Valid;
@@ -25,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 @Validated
 @RequiredArgsConstructor
 public class AssessmentSolutionQueryService {
+	private final TransactionTemplate transactionTemplate;
 	private final AssessmentRepository assessmentRepository;
 	private final ProblemQueryManager problemQueryManager;
 
@@ -32,17 +34,19 @@ public class AssessmentSolutionQueryService {
 	 * 사용자가 문제를 푼 경우에만 정답 조회가 가능합니다.
 	 * @param query
 	 */
-	@Transactional(readOnly = true)
 	public AssessmentSolutionQueryResult querySolutions(@NotNull @Valid final AssessmentSolutionQuery query) {
-		final Assessment solvedAssessment = getSubmittedAssessment(query.assessmentId(), query.requestMemberId(), query.requestMemberRole());
+		// 트랜잭션 내에서 조회
+		final List<Long> problemIds = transactionTemplate.execute(status -> {
+			final Assessment solvedAssessment = getSubmittedAssessment(query.assessmentId(), query.requestMemberId(), query.requestMemberRole());
+			return solvedAssessment.getAssessmentItems().stream()
+				.map(AssessmentItem::getProblemId)
+				.toList();
+		});
 
-		final List<ProblemSolutionResult> results = solvedAssessment.getAssessmentItems().stream()
-			.map(AssessmentItem::getProblemId)
+		return new AssessmentSolutionQueryResult(problemIds.stream()
 			.map(problemQueryManager::getProblemInfo)
 			.map(ProblemSolutionResult::from)
-			.toList();
-
-		return new AssessmentSolutionQueryResult(results);
+			.toList());
 	}
 
 	private Assessment getSubmittedAssessment(final Long assessmentId, final Long requestMemberId, final Role role) {

--- a/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentSolutionQueryServiceTest.java
+++ b/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentSolutionQueryServiceTest.java
@@ -3,12 +3,14 @@ package kr.co.mathrank.domain.problem.assessment.service;
 import java.time.Duration;
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import kr.co.mathrank.common.role.Role;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentSolutionQuery;
 import kr.co.mathrank.domain.problem.assessment.entity.Assessment;
 import kr.co.mathrank.domain.problem.assessment.exception.CannotGetSolutionException;
@@ -16,25 +18,32 @@ import kr.co.mathrank.domain.problem.assessment.repository.AssessmentRepository;
 import kr.co.mathrank.domain.problem.assessment.repository.AssessmentSubmissionRepository;
 
 @SpringBootTest
-@Transactional
 class AssessmentSolutionQueryServiceTest {
 	@Autowired
 	private AssessmentSolutionQueryService solutionQueryService;
 	@Autowired
 	private AssessmentRepository assessmentRepository;
-	@Autowired
-	private AssessmentSubmissionRepository assessmentSubmissionRepository;
 
 	@Test
 	void 풀지_않은_시험지의_정답_조회시_예외발생() {
 		final Long requestMemberId = 1L;
 
 		final Assessment assessment = Assessment.unlimited(1L, "testAssessment", Duration.ofMinutes(100L));
-		assessment.registerSubmission(requestMemberId, List.of(), Duration.ofMinutes(1L), true);
 		assessmentRepository.save(assessment);
 
 		Assertions.assertThrows(CannotGetSolutionException.class, () -> solutionQueryService.querySolutions(
-			new AssessmentSolutionQuery(assessment.getId(), requestMemberId + 1)));
+			new AssessmentSolutionQuery(assessment.getId(), requestMemberId, Role.USER)));
+	}
+
+	@Test
+	void 어드민은_항상_통과() {
+		final Long requestMemberId = 1L;
+
+		final Assessment assessment = Assessment.unlimited(1L, "testAssessment", Duration.ofMinutes(100L));
+		assessmentRepository.save(assessment);
+
+		Assertions.assertDoesNotThrow(() -> solutionQueryService.querySolutions(
+			new AssessmentSolutionQuery(assessment.getId(), requestMemberId, Role.ADMIN)));
 	}
 
 	@Test
@@ -46,6 +55,11 @@ class AssessmentSolutionQueryServiceTest {
 		assessmentRepository.save(assessment);
 
 		Assertions.assertDoesNotThrow(() -> solutionQueryService.querySolutions(
-			new AssessmentSolutionQuery(assessment.getId(), requestMemberId)));
+			new AssessmentSolutionQuery(assessment.getId(), requestMemberId, Role.USER)));
+	}
+
+	@AfterEach
+	void clear() {
+		assessmentRepository.deleteAll();
 	}
 }


### PR DESCRIPTION
- lazy loading 으로 인한 에러 수정
  - 트랜잭션 범위 `TransactionTemplate`으로 범위 제한
- 어드민 `Role.ADMIN` 은 항상 가능하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Role-aware access when viewing assessment and contest solutions: admins can access directly; other users must have a valid submission.
  * More consistent behavior under concurrent access due to transactional retrieval of submitted solutions.
* **Bug Fixes**
  * Clearer error when no eligible submission exists instead of a generic failure.
* **Tests**
  * Test setup updated to ensure isolation and cleanup after each test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->