### PR TITLE
fix(contents): contentId pathVariable로 받도록 수정

### DIFF
--- a/app/api/mathrank-contents-api/src/main/java/kr/co/mathrank/app/api/contents/ContentsController.java
+++ b/app/api/mathrank-contents-api/src/main/java/kr/co/mathrank/app/api/contents/ContentsController.java
@@ -51,9 +51,10 @@ public class ContentsController {
 	@Operation(summary = "자료 수정 API", description = "관리지(ADMIN)만 사용 가능합니다.")
 	@Authorization(values = Role.ADMIN)
 	public ResponseEntity<Void> update(
+		@PathVariable final Long contentId,
 		@RequestBody @Valid final Requests.ContentUpdateRequest request
 	) {
-		final ContentUpdateCommand command = request.toCommand();
+		final ContentUpdateCommand command = request.toCommand(contentId);
 		contentService.update(command);
 
 		return ResponseEntity.ok().build();

--- a/app/api/mathrank-contents-api/src/main/java/kr/co/mathrank/app/api/contents/Requests.java
+++ b/app/api/mathrank-contents-api/src/main/java/kr/co/mathrank/app/api/contents/Requests.java
@@ -42,8 +42,6 @@ public class Requests {
 
 	record ContentUpdateRequest(
 		@NotNull
-		Long contentId,
-		@NotNull
 		String title,
 		@NotNull
 		String text,
@@ -52,7 +50,7 @@ public class Requests {
 		List<ContentFileRegisterCommand> fileSources,
 		List<String> videoLinks
 	) {
-		public ContentUpdateCommand toCommand() {
+		public ContentUpdateCommand toCommand(final Long contentId) {
 			return new ContentUpdateCommand(
 				contentId,
 				title,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated the content update API to read the content ID from the URL path instead of the request body, aligning with REST conventions and reducing risk of ID mismatches. The request payload no longer requires a content ID.

- Documentation
  - Clarified request expectations for the update endpoint to reflect the path-based content ID.

- Breaking change notice
  - Clients must provide the content ID in the endpoint path and omit it from the request body when updating content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->