### PR TITLE
feat(point): 사용자 정보 조회 시, 잔여 포인트 함께 조회되도록 기능 추가

### DIFF
--- a/app/api/mathrank-member-read-api/build.gradle
+++ b/app/api/mathrank-member-read-api/build.gradle
@@ -6,5 +6,6 @@ dependencies {
 
     implementation project(':domain:mathrank-auth-domain')
     implementation project(':client:external:mathrank-school')
+    implementation project(':client:internal:mathrank-point-client')
     implementation project(':app:api:mathrank-api-common')
 }

--- a/app/api/mathrank-member-read-api/src/main/java/kr/co/mathrank/app/api/member/read/MemberDetailQueryController.java
+++ b/app/api/mathrank-member-read-api/src/main/java/kr/co/mathrank/app/api/member/read/MemberDetailQueryController.java
@@ -12,6 +12,8 @@ import kr.co.mathrank.app.api.common.authentication.MemberPrincipal;
 import kr.co.mathrank.client.external.school.RequestType;
 import kr.co.mathrank.client.external.school.SchoolClient;
 import kr.co.mathrank.client.external.school.SchoolInfo;
+import kr.co.mathrank.client.internal.point.PointClient;
+import kr.co.mathrank.client.internal.point.PointInfo;
 import kr.co.mathrank.domain.auth.dto.MemberInfoResult;
 import kr.co.mathrank.domain.auth.service.MemberQueryService;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,8 @@ import lombok.RequiredArgsConstructor;
 public class MemberDetailQueryController {
 	private final MemberQueryService memberQueryService;
 	private final SchoolClient schoolClient;
+	private final PointClient pointClient;
+
 
 	@GetMapping("/api/v1/member/info/my")
 	@Operation(summary = "내 계정 정보 조회 API", description = "내 계정의 정보를 조회합니다.")
@@ -32,7 +36,8 @@ public class MemberDetailQueryController {
 		final MemberInfoResult result = memberQueryService.getInfo(memberPrincipal.memberId());
 		final SchoolInfo schoolInfo = schoolClient.getSchool(RequestType.JSON.getType(), result.schoolCode())
 			.orElse(SchoolInfo.none());
+		final PointInfo pointInfo = pointClient.getRemainPoint(memberPrincipal.memberId());
 
-		return ResponseEntity.ok(Responses.MemberInfoDetailResponse.from(result, schoolInfo));
+		return ResponseEntity.ok(Responses.MemberInfoDetailResponse.from(result, schoolInfo, pointInfo));
 	}
 }

--- a/app/api/mathrank-member-read-api/src/main/java/kr/co/mathrank/app/api/member/read/Responses.java
+++ b/app/api/mathrank-member-read-api/src/main/java/kr/co/mathrank/app/api/member/read/Responses.java
@@ -3,6 +3,7 @@ package kr.co.mathrank.app.api.member.read;
 import java.time.LocalDateTime;
 
 import kr.co.mathrank.client.external.school.SchoolInfo;
+import kr.co.mathrank.client.internal.point.PointInfo;
 import kr.co.mathrank.common.role.Role;
 import kr.co.mathrank.domain.auth.dto.MemberInfoResult;
 import kr.co.mathrank.domain.auth.entity.MemberType;
@@ -16,9 +17,11 @@ public class Responses {
 		LocalDateTime createdAt,
 		Boolean agreeToPrivacyPolicy,
 		Boolean pending,
-		SchoolResponse schoolDetail
+		SchoolResponse schoolDetail,
+		Long remainPoint
 	) {
-		public static MemberInfoDetailResponse from(final MemberInfoResult result, final SchoolInfo schoolInfo) {
+		public static MemberInfoDetailResponse from(final MemberInfoResult result, final SchoolInfo schoolInfo, final
+			PointInfo pointInfo) {
 			return new MemberInfoDetailResponse(
 				String.valueOf(result.memberId()),
 				result.nickName(),
@@ -27,7 +30,8 @@ public class Responses {
 				result.createdAt(),
 				result.agreeToPrivacyPolicy(),
 				result.pending(),
-				SchoolResponse.from(schoolInfo)
+				SchoolResponse.from(schoolInfo),
+				pointInfo.remainPoint()
 			);
 		}
 	}

--- a/app/api/mathrank-point-inner-api/build.gradle
+++ b/app/api/mathrank-point-inner-api/build.gradle
@@ -1,0 +1,9 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+    implementation project(':domain:mathrank-point-domain')
+    implementation project(':app:api:mathrank-api-common')
+}

--- a/app/api/mathrank-point-inner-api/src/main/java/kr/co/mathrank/app/api/point/inner/PointInnerController.java
+++ b/app/api/mathrank-point-inner-api/src/main/java/kr/co/mathrank/app/api/point/inner/PointInnerController.java
@@ -1,0 +1,28 @@
+package kr.co.mathrank.app.api.point.inner;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import kr.co.mathrank.domain.point.dto.PointQuery;
+import kr.co.mathrank.domain.point.dto.PointQueryResult;
+import kr.co.mathrank.domain.point.service.PointQueryService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class PointInnerController {
+	private final PointQueryService pointQueryService;
+
+	@GetMapping("/api/inner/v1/point")
+	@Operation(hidden = true)
+	public ResponseEntity<PointQueryResult> queryPoint(
+		@RequestParam final Long memberId
+	) {
+		final PointQueryResult result = pointQueryService.queryPoint(new PointQuery(memberId));
+
+		return ResponseEntity.ok(result);
+	}
+}

--- a/app/api/monolith-api/build.gradle
+++ b/app/api/monolith-api/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 
     implementation project(':app:api:mathrank-member-api')
     implementation project(':app:api:mathrank-point-api')
+    implementation project(':app:api:mathrank-point-inner-api')
     implementation project(':app:api:mathrank-member-read-api')
     implementation project(':app:api:mathrank-auth-api')
     implementation project(':app:api:mathrank-course-api')

--- a/client/internal/mathrank-point-client/build.gradle
+++ b/client/internal/mathrank-point-client/build.gradle
@@ -1,0 +1,8 @@
+plugins {
+    id 'java-library'
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+}

--- a/client/internal/mathrank-point-client/src/main/java/kr/co/mathrank/client/internal/point/PointClient.java
+++ b/client/internal/mathrank-point-client/src/main/java/kr/co/mathrank/client/internal/point/PointClient.java
@@ -1,0 +1,69 @@
+package kr.co.mathrank.client.internal.point;
+
+import java.time.Duration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.client.RestClient;
+
+import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.client.config.TimeoutConfiguredClient;
+import kr.co.mathrank.client.exception.aspect.Client;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Component
+@Client
+public class PointClient extends TimeoutConfiguredClient {
+	private static final String URL_FORMAT = "%s:%s";
+
+	private final PointClientProperties properties;
+	private final RestClient restClient;
+
+	PointClient(final PointClientProperties properties) {
+		this.properties = properties;
+		this.restClient = RestClient.builder()
+			.requestFactory(configureTimeoutConfiguration(
+				Duration.ofSeconds(properties.getConnectionTimeoutSeconds()),
+				Duration.ofSeconds(properties.getReadTimeoutSeconds()))
+			)
+			.baseUrl(getUrlFormat(properties.getHost(), properties.getPort()))
+			.build();
+	}
+
+	public PointInfo getRemainPoint(final Long memberId) {
+		return restClient.get()
+			.uri(uriBuilder -> uriBuilder
+				.path(properties.getUri())
+				.queryParam("memberId", memberId)
+				.build())
+			.retrieve()
+			.body(PointInfo.class);
+	}
+
+	private String getUrlFormat(final String host, final Integer port) {
+		return URL_FORMAT.formatted(host, port);
+	};
+
+	@Getter
+	@Configuration
+	@ConfigurationProperties("client.point")
+	@NoArgsConstructor
+	@Validated
+	@Setter
+	static class PointClientProperties {
+		@NotNull
+		private String host = "http://localhost";
+		@NotNull
+		private Integer port = 8080;
+		@NotNull
+		private String uri = "/api/inner/v1/point";
+		@NotNull
+		private Integer connectionTimeoutSeconds;
+		@NotNull
+		private Integer readTimeoutSeconds;
+	}
+}

--- a/client/internal/mathrank-point-client/src/main/java/kr/co/mathrank/client/internal/point/PointInfo.java
+++ b/client/internal/mathrank-point-client/src/main/java/kr/co/mathrank/client/internal/point/PointInfo.java
@@ -1,0 +1,6 @@
+package kr.co.mathrank.client.internal.point;
+
+public record PointInfo(
+	Long remainPoint
+) {
+}

--- a/domain/mathrank-point-domain/src/main/java/kr/co/mathrank/domain/point/dto/PointQuery.java
+++ b/domain/mathrank-point-domain/src/main/java/kr/co/mathrank/domain/point/dto/PointQuery.java
@@ -1,0 +1,9 @@
+package kr.co.mathrank.domain.point.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PointQuery(
+	@NotNull
+	Long targetMemberId
+) {
+}

--- a/domain/mathrank-point-domain/src/main/java/kr/co/mathrank/domain/point/dto/PointQueryResult.java
+++ b/domain/mathrank-point-domain/src/main/java/kr/co/mathrank/domain/point/dto/PointQueryResult.java
@@ -1,0 +1,6 @@
+package kr.co.mathrank.domain.point.dto;
+
+public record PointQueryResult(
+	Long remainPoint
+) {
+}

--- a/domain/mathrank-point-domain/src/main/java/kr/co/mathrank/domain/point/service/PointQueryService.java
+++ b/domain/mathrank-point-domain/src/main/java/kr/co/mathrank/domain/point/service/PointQueryService.java
@@ -1,0 +1,34 @@
+package kr.co.mathrank.domain.point.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.domain.point.dto.PointQuery;
+import kr.co.mathrank.domain.point.dto.PointQueryResult;
+import kr.co.mathrank.domain.point.entity.UserPoint;
+import kr.co.mathrank.domain.point.repository.UserPointRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PointQueryService {
+	private final UserPointRepository userPointRepository;
+
+	/**
+	 * 멤버를 찾을 수 없으면 0 을 응답합니다.
+	 * @param query
+	 * @return
+	 */
+	public PointQueryResult queryPoint(
+		@NotNull @Valid final PointQuery query
+	) {
+		final Long remainPoint = userPointRepository.findByUserId(query.targetMemberId())
+			.map(UserPoint::getPointAmount)
+			.orElseGet(() -> 0L);
+
+		return new PointQueryResult(remainPoint);
+	}
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,6 +8,7 @@ include(
 
         'app:api',
         'app:api:mathrank-point-api',
+        'app:api:mathrank-point-inner-api',
         'app:api:mathrank-contents-api',
         'app:api:mathrank-member-read-api',
         'app:api:mathrank-board-api',

--- a/settings.gradle
+++ b/settings.gradle
@@ -43,6 +43,7 @@ include(
         'client:mathrank-client-config',
         'client:mathrank-client-exception',
         'client:internal',
+        'client:internal:mathrank-point-client',
         'client:internal:mathrank-course-client',
         'client:internal:mathrank-member-client',
         'client:internal:mathrank-problem-client',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Member details now display the remaining point balance on the My Info/profile screen, populated in real time.

- API
  - Added an internal endpoint to retrieve a member’s remaining points.

- Chores
  - Introduced internal client and domain support for point queries and integrated them across modules to enable the new balance display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->