### PR TITLE
hotfix(contents): 주문 성공여부와 상관없이 조회가능하던 에러 수정

### DIFF
--- a/domain/mathrank-contents-domain/src/main/java/kr/co/mathrank/domain/contents/service/ContentService.java
+++ b/domain/mathrank-contents-domain/src/main/java/kr/co/mathrank/domain/contents/service/ContentService.java
@@ -20,6 +20,7 @@ import kr.co.mathrank.domain.contents.dto.ContentReadQueryResult;
 import kr.co.mathrank.domain.contents.dto.ContentRegisterCommand;
 import kr.co.mathrank.domain.contents.dto.ContentUpdateCommand;
 import kr.co.mathrank.domain.contents.entity.Content;
+import kr.co.mathrank.domain.contents.entity.OrderStatus;
 import kr.co.mathrank.domain.contents.exception.CannotFoundContentException;
 import kr.co.mathrank.domain.contents.exception.NotPurchasedContentException;
 import kr.co.mathrank.domain.contents.repository.ContentRepository;
@@ -100,7 +101,7 @@ public class ContentService {
 		}
 
 		// 일반 사용자는 결제해야지 조회 가능
-		if (content.getContentOrders().stream().anyMatch(order -> order.getUserId().equals(userId))) {
+		if (content.getContentOrders().stream().anyMatch(order -> order.getUserId().equals(userId) && order.getOrderStatus() == OrderStatus.SUCCEEDED)) {
 			return;
 		}
 


### PR DESCRIPTION
주문 완료 상태일때만 조회 가능하게 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected content access validation so only successfully completed purchases grant access.
  * Users with pending, failed, or canceled orders can no longer view paid content.
  * Reduces accidental access denials for valid purchasers and prevents unintended access for invalid orders.
  * Error handling remains consistent for non-purchased users; admin access is unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->