### PR TITLE
feat(contents): 주문 상태별 조회 기능 구현

### DIFF
--- a/app/api/mathrank-contents-api/src/main/java/kr/co/mathrank/app/api/contents/ContentsOrderController.java
+++ b/app/api/mathrank-contents-api/src/main/java/kr/co/mathrank/app/api/contents/ContentsOrderController.java
@@ -16,6 +16,7 @@ import kr.co.mathrank.common.page.PageResult;
 import kr.co.mathrank.domain.contents.dto.ContentOrderCommand;
 import kr.co.mathrank.domain.contents.dto.ContentOrderQuery;
 import kr.co.mathrank.domain.contents.dto.ContentOrderQueryResult;
+import kr.co.mathrank.domain.contents.entity.OrderStatus;
 import kr.co.mathrank.domain.contents.service.ContentOrderQueryService;
 import kr.co.mathrank.domain.contents.service.ContentOrderService;
 import lombok.RequiredArgsConstructor;
@@ -62,10 +63,11 @@ public class ContentsOrderController {
 	public ResponseEntity<PageResult<ContentOrderQueryResult>> queryOrders(
 		@RequestParam(defaultValue = "1") final Integer pageNumber,
 		@RequestParam(defaultValue = "10") final Integer pageSize,
+		@RequestParam(required = false) final OrderStatus orderStatus,
 		@LoginInfo final MemberPrincipal memberPrincipal
 	) {
 		final PageResult<ContentOrderQueryResult> result = contentOrderQueryService.contentOrderPageQuery(
-			new ContentOrderQuery(memberPrincipal.memberId()),
+			new ContentOrderQuery(memberPrincipal.memberId(), orderStatus),
 			pageSize,
 			pageNumber
 		);

--- a/domain/mathrank-contents-domain/src/main/java/kr/co/mathrank/domain/contents/dto/ContentOrderQuery.java
+++ b/domain/mathrank-contents-domain/src/main/java/kr/co/mathrank/domain/contents/dto/ContentOrderQuery.java
@@ -1,8 +1,9 @@
 package kr.co.mathrank.domain.contents.dto;
 
-import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.domain.contents.entity.OrderStatus;
 
 public record ContentOrderQuery(
-	Long memberId
+	Long memberId,
+	OrderStatus orderStatus
 ) {
 }

--- a/domain/mathrank-contents-domain/src/main/java/kr/co/mathrank/domain/contents/repository/ContentOrderQueryRepositoryImpl.java
+++ b/domain/mathrank-contents-domain/src/main/java/kr/co/mathrank/domain/contents/repository/ContentOrderQueryRepositoryImpl.java
@@ -12,6 +12,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import kr.co.mathrank.domain.contents.dto.ContentOrderQuery;
 import kr.co.mathrank.domain.contents.entity.ContentOrder;
+import kr.co.mathrank.domain.contents.entity.OrderStatus;
 import kr.co.mathrank.domain.contents.entity.QContentOrder;
 import lombok.RequiredArgsConstructor;
 
@@ -50,7 +51,8 @@ class ContentOrderQueryRepositoryImpl implements ContentOrderQueryRepository {
 
 	private BooleanExpression[] whereConditions(ContentOrderQuery query) {
 		return new BooleanExpression[] {
-			matchMemberId(query.memberId())
+			matchMemberId(query.memberId()),
+			matchOrderStatus(query.orderStatus())
 		};
 	}
 
@@ -60,5 +62,13 @@ class ContentOrderQueryRepositoryImpl implements ContentOrderQueryRepository {
 		}
 
 		return QContentOrder.contentOrder.userId.eq(memberId);
+	}
+
+	private BooleanExpression matchOrderStatus(final OrderStatus orderStatus) {
+		if (orderStatus == null) {
+			return null;
+		}
+
+		return QContentOrder.contentOrder.orderStatus.eq(orderStatus);
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to filter content orders by status in the orders list. You can optionally specify an order status to narrow results (e.g., pending, completed, canceled), making it easier to find relevant orders. If no status is provided, results remain unchanged. This enhancement applies to both the UI and API endpoints that return paginated order lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->