### PR TITLE
hotfix(assessment): 일부 문제 사제 시, assessment삭제 안되던 오류 수정

### DIFF
--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/repository/AssessmentItemRepository.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/repository/AssessmentItemRepository.java
@@ -1,0 +1,19 @@
+package kr.co.mathrank.domain.problem.assessment.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import kr.co.mathrank.domain.problem.assessment.entity.Assessment;
+import kr.co.mathrank.domain.problem.assessment.entity.AssessmentItem;
+
+public interface AssessmentItemRepository extends JpaRepository<AssessmentItem, Long> {
+	@Query("""
+SELECT assItem FROM AssessmentItem assItem
+LEFT JOIN FETCH assItem.assessment
+WHERE assItem.problemId = :problemId
+""")
+	List<AssessmentItem> findAllContainsProblemId(@Param("problemId") final Long problemId);
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/repository/AssessmentRepository.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/repository/AssessmentRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import jakarta.persistence.LockModeType;
 import kr.co.mathrank.domain.problem.assessment.entity.Assessment;
 import kr.co.mathrank.domain.problem.assessment.entity.AssessmentPeriodType;
+import kr.co.mathrank.domain.problem.assessment.entity.AssessmentSubmission;
 
 public interface AssessmentRepository extends JpaRepository<Assessment, Long>, AssessmentQueryRepository{
 	@Query("""
@@ -50,11 +51,4 @@ LEFT JOIN FETCH ass.assessmentSubmissions assSub
 WHERE ass.id = :assessmentId AND assSub.memberId = :memberId
 """)
 	Optional<Assessment> findByAssessmentIdAndSubmissionMemberId(@Param("assessmentId") Long assessmentId, @Param("memberId") Long memberId);
-
-	@Query("""
-SELECT ass FROM Assessment ass
-LEFT JOIN FETCH ass.assessmentItems assItem
-WHERE assItem.problemId = :problemId
-""")
-	List<Assessment> findAllContainsProblemId(@Param("problemId") final Long problemId);
 }

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentDeleteService.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentDeleteService.java
@@ -11,8 +11,10 @@ import jakarta.validation.constraints.NotNull;
 import kr.co.mathrank.common.role.Role;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentDeleteCommand;
 import kr.co.mathrank.domain.problem.assessment.entity.Assessment;
+import kr.co.mathrank.domain.problem.assessment.entity.AssessmentItem;
 import kr.co.mathrank.domain.problem.assessment.exception.CannotDeleteAssessmentException;
 import kr.co.mathrank.domain.problem.assessment.exception.NoSuchAssessmentException;
+import kr.co.mathrank.domain.problem.assessment.repository.AssessmentItemRepository;
 import kr.co.mathrank.domain.problem.assessment.repository.AssessmentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 @Validated
 public class AssessmentDeleteService {
 	private final AssessmentRepository assessmentRepository;
+	private final AssessmentItemRepository assessmentItemRepository;
 
 	@Transactional
 	public void delete(@NotNull @Valid final AssessmentDeleteCommand command) {
@@ -33,8 +36,10 @@ public class AssessmentDeleteService {
 
 	@Transactional
 	public void deleteByProblemId(@NotNull final Long problemId) {
-		final List<Assessment> assessments = assessmentRepository.findAllContainsProblemId(problemId);
-		assessmentRepository.deleteAll(assessments);
+		final List<AssessmentItem> assessments = assessmentItemRepository.findAllContainsProblemId(problemId);
+		assessmentRepository.deleteAll(assessments.stream()
+			.map(AssessmentItem::getAssessment)
+			.toList());
 		log.info("[AssessmentDeleteService.deleteByProblemId] deleted assessment related with problemId - problemId: {}, assessmentCount: {}", problemId, assessments.size());
 	}
 

--- a/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentDeleteServiceTest.java
+++ b/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentDeleteServiceTest.java
@@ -1,0 +1,57 @@
+package kr.co.mathrank.domain.problem.assessment.service;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import kr.co.mathrank.domain.problem.assessment.entity.Assessment;
+import kr.co.mathrank.domain.problem.assessment.entity.AssessmentItem;
+import kr.co.mathrank.domain.problem.assessment.repository.AssessmentItemRepository;
+import kr.co.mathrank.domain.problem.assessment.repository.AssessmentRepository;
+
+@SpringBootTest(properties = """
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+""")
+class AssessmentDeleteServiceTest {
+	@Autowired
+	private AssessmentDeleteService assessmentDeleteService;
+	@Autowired
+	private AssessmentRepository assessmentRepository;
+	@PersistenceContext
+	private EntityManager entityManager;
+	@Autowired
+	private AssessmentItemRepository assessmentItemRepository;
+
+	@Test
+	@Transactional
+	void 문제가_여러개인_문제집에서_원본문제가_삭제됐을때_문제집이_삭제된다() {
+		final Assessment assessment = Assessment.unlimited(1L, "name", Duration.ofHours(1L));
+		assessment.replaceItems(List.of(
+			AssessmentItem.of(1L, 20),
+			AssessmentItem.of(2L, 80)
+		));
+
+		assessmentRepository.save(assessment);
+
+		entityManager.flush();
+		entityManager.clear();
+
+		// 속한 문제 하나 삭제한다
+		assessmentDeleteService.deleteByProblemId(1L);
+
+		entityManager.flush();
+		entityManager.clear();
+
+		// 삭제된 문제가 속하는 시험지는 모두 삭제한다
+		Assertions.assertEquals(0, assessmentRepository.count());
+		Assertions.assertEquals(0, assessmentItemRepository.count());
+	}
+}


### PR DESCRIPTION
- join fetch 에 대한 where 로 인해 collection 이 정확히 초기화되지 않았음 자식 엔티티를 모두 삭제하지 않고 부모 엔티티를 삭제하여 발생하던 오류

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced assessment deletion logic to better handle multi-item assessments, ensuring consistent data cleanup when assessment items are removed.

* **Tests**
  * Added comprehensive test coverage for cascading deletion behavior in assessment operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->