### PR TITLE
feat(single-problem): 개별문제 이름 업데이트 api 구현

### DIFF
--- a/app/api/mathrank-problem-single-api/src/main/java/kr/co/mathrank/app/api/problem/single/controller/SingleProblemController.java
+++ b/app/api/mathrank-problem-single-api/src/main/java/kr/co/mathrank/app/api/problem/single/controller/SingleProblemController.java
@@ -9,8 +9,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.filter.RequestContextFilter;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -28,11 +31,13 @@ import kr.co.mathrank.domain.problem.single.dto.SingleProblemSolutionQuery;
 import kr.co.mathrank.domain.problem.single.dto.SingleProblemSolutionQueryResult;
 import kr.co.mathrank.domain.problem.single.dto.SingleProblemSolveCommand;
 import kr.co.mathrank.domain.problem.single.dto.SingleProblemSolveResult;
+import kr.co.mathrank.domain.problem.single.dto.SingleProblemNameUpdateCommand;
 import kr.co.mathrank.domain.problem.single.service.ChallengerQueryService;
 import kr.co.mathrank.domain.problem.single.service.SingleProblemDeleteService;
 import kr.co.mathrank.domain.problem.single.service.SingleProblemRankQueryService;
 import kr.co.mathrank.domain.problem.single.service.SingleProblemService;
 import kr.co.mathrank.domain.problem.single.service.SingleProblemSolutionQueryService;
+import kr.co.mathrank.domain.problem.single.service.SingleProblemUpdateService;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "개별 문제 API")
@@ -44,6 +49,7 @@ public class SingleProblemController {
 	private final ChallengerQueryService challengerQueryService;
 	private final SingleProblemDeleteService singleProblemDeleteService;
 	private final SingleProblemSolutionQueryService singleProblemSolutionQueryService;
+	private final SingleProblemUpdateService singleProblemUpdateService;
 
 	@Operation(summary = "개별 문제 풀이 API", description = "해당 사용자의 문제풀이를 채점하고, 결과를 저장합니다. 풀이 결과는 모두 저장됩니다")
 	@PostMapping("/api/v1/problem/single/solve")
@@ -132,5 +138,18 @@ public class SingleProblemController {
 		final SingleProblemSolutionQueryResult result = singleProblemSolutionQueryService.getSolution(query);
 
 		return ResponseEntity.ok(result);
+	}
+
+	@Operation(summary = "개별문제 수정 API - 관리자 전용", description = "이미 문제를 푼 사용자만 조회 가능합니다.")
+	@PutMapping("/api/v1/problem/single/{singleProblemId}/title")
+	@Authorization(values = Role.ADMIN)
+	public ResponseEntity<SingleProblemSolutionQueryResult> querySolution(
+		@PathVariable final Long singleProblemId,
+		@RequestBody @Valid final SingleProblemNameUpdateRequest request
+	) {
+		final SingleProblemNameUpdateCommand command = request.toCommand(singleProblemId);
+		singleProblemUpdateService.update(command);
+
+		return ResponseEntity.ok().build();
 	}
 }

--- a/app/api/mathrank-problem-single-api/src/main/java/kr/co/mathrank/app/api/problem/single/controller/SingleProblemController.java
+++ b/app/api/mathrank-problem-single-api/src/main/java/kr/co/mathrank/app/api/problem/single/controller/SingleProblemController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.filter.RequestContextFilter;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -140,10 +139,10 @@ public class SingleProblemController {
 		return ResponseEntity.ok(result);
 	}
 
-	@Operation(summary = "개별문제 수정 API - 관리자 전용", description = "이미 문제를 푼 사용자만 조회 가능합니다.")
+	@Operation(summary = "개별문제 이름 수정 API - 관리자 전용", description = "개별문제 이름을 수정합니다.")
 	@PutMapping("/api/v1/problem/single/{singleProblemId}/title")
 	@Authorization(values = Role.ADMIN)
-	public ResponseEntity<SingleProblemSolutionQueryResult> querySolution(
+	public ResponseEntity<Void> updateSingleProblemName(
 		@PathVariable final Long singleProblemId,
 		@RequestBody @Valid final SingleProblemNameUpdateRequest request
 	) {

--- a/app/api/mathrank-problem-single-api/src/main/java/kr/co/mathrank/app/api/problem/single/controller/SingleProblemNameUpdateRequest.java
+++ b/app/api/mathrank-problem-single-api/src/main/java/kr/co/mathrank/app/api/problem/single/controller/SingleProblemNameUpdateRequest.java
@@ -1,0 +1,13 @@
+package kr.co.mathrank.app.api.problem.single.controller;
+
+import jakarta.validation.constraints.NotBlank;
+import kr.co.mathrank.domain.problem.single.dto.SingleProblemNameUpdateCommand;
+
+public record SingleProblemNameUpdateRequest(
+	@NotBlank
+	String singleProblemTitle
+) {
+	public SingleProblemNameUpdateCommand toCommand(final Long singleProblemId) {
+		return new SingleProblemNameUpdateCommand(singleProblemId, singleProblemTitle());
+	}
+}

--- a/app/consumer/mathrank-problem-single-read-consumer-monolith/src/main/java/kr/co/mathrank/app/consumer/problem/single/read/consumer/monolith/EventPayloads.java
+++ b/app/consumer/mathrank-problem-single-read-consumer-monolith/src/main/java/kr/co/mathrank/app/consumer/problem/single/read/consumer/monolith/EventPayloads.java
@@ -7,6 +7,7 @@ import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
 import kr.co.mathrank.domain.problem.core.PastProblem;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemAttemptStatsUpdateCommand;
+import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelNameUpdateCommand;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelRegisterCommand;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelUpdateCommand;
 
@@ -100,6 +101,20 @@ public class EventPayloads {
 		Long memberId
 	) implements EventPayload {
 
+	}
+
+	record SingleProblemNameUpdatedEventPayload(
+		Long singleProblemId,
+		String singleProblemName,
+		Long problemId,
+		Long memberId
+	) implements EventPayload {
+		public SingleProblemReadModelNameUpdateCommand toCommand() {
+			return new SingleProblemReadModelNameUpdateCommand(
+				singleProblemId,
+				singleProblemName
+			);
+		}
 	}
 
 	record ProblemDeletedEvent(

--- a/app/consumer/mathrank-problem-single-read-consumer-monolith/src/main/java/kr/co/mathrank/app/consumer/problem/single/read/consumer/monolith/SingleProblemReadMonolithEventListener.java
+++ b/app/consumer/mathrank-problem-single-read-consumer-monolith/src/main/java/kr/co/mathrank/app/consumer/problem/single/read/consumer/monolith/SingleProblemReadMonolithEventListener.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 import kr.co.mathrank.app.consumer.problem.single.read.consumer.monolith.EventPayloads.ProblemDeletedEvent;
 import kr.co.mathrank.app.consumer.problem.single.read.consumer.monolith.EventPayloads.ProblemUpdatedEventPayload;
 import kr.co.mathrank.app.consumer.problem.single.read.consumer.monolith.EventPayloads.SingleProblemDeletedEvent;
+import kr.co.mathrank.app.consumer.problem.single.read.consumer.monolith.EventPayloads.SingleProblemNameUpdatedEventPayload;
 import kr.co.mathrank.app.consumer.problem.single.read.consumer.monolith.EventPayloads.SingleProblemRegisteredEventPayload;
 import kr.co.mathrank.app.consumer.problem.single.read.consumer.monolith.EventPayloads.SingleProblemSolvedEventPayload;
 import kr.co.mathrank.common.event.Event;
@@ -37,6 +38,7 @@ public class SingleProblemReadMonolithEventListener {
 	private static String SINGLE_PROBLEM_REGISTERED_TOPIC = "single-problem-registered";
 	private static final String SINGLE_PROBLEM_DELETED_TOPIC = "single-problem-deleted";
 	private static final String PROBLEM_DELETED_EVENT = "problem-deleted";
+	private static final String SINGLE_PROBLEM_NAME_UPDATED_EVENT = "single-problem-name-updated";
 	private final SingleProblemReadModelDeleteService singleProblemReadModelDeleteService;
 
 	/**
@@ -53,6 +55,17 @@ public class SingleProblemReadMonolithEventListener {
 		log.debug("[SingleProblemReadMonolithEventListener.listenInfoUpdatedEvent] Monolith event received: {}", monolithEvent);
 		final Event<ProblemUpdatedEventPayload> event = Event.fromJson(monolithEvent.payload(), ProblemUpdatedEventPayload.class);
 		singleProblemUpdateService.updateProblemInfo(event.getPayload().toCommand());
+	}
+
+	@Async
+	@EventListener(MonolithEvent.class)
+	public void listenSingleProblemNameUpdatedEvent(final MonolithEvent monolithEvent) {
+		if (!monolithEvent.isExpectedTopic(SINGLE_PROBLEM_NAME_UPDATED_EVENT)) {
+			return;
+		}
+		log.debug("[SingleProblemReadMonolithEventListener.listenSingleProblemNameUpdatedEvent] Monolith event received: {}", monolithEvent);
+		final Event<SingleProblemNameUpdatedEventPayload> event = Event.fromJson(monolithEvent.payload(), SingleProblemNameUpdatedEventPayload.class);
+		singleProblemUpdateService.updateSingleProblemName(event.getPayload().toCommand());
 	}
 
 	/**

--- a/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/dto/SingleProblemNameUpdateCommand.java
+++ b/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/dto/SingleProblemNameUpdateCommand.java
@@ -3,7 +3,7 @@ package kr.co.mathrank.domain.problem.single.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-public record SingleProblemUpdateCommand(
+public record SingleProblemNameUpdateCommand(
 	@NotNull
 	Long singleProblemId,
 	@NotBlank

--- a/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/dto/SingleProblemUpdateCommand.java
+++ b/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/dto/SingleProblemUpdateCommand.java
@@ -1,0 +1,12 @@
+package kr.co.mathrank.domain.problem.single.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record SingleProblemUpdateCommand(
+	@NotNull
+	Long singleProblemId,
+	@NotBlank
+	String singleProblemName
+) {
+}

--- a/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/entity/SingleProblem.java
+++ b/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/entity/SingleProblem.java
@@ -19,6 +19,7 @@ import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
@@ -31,6 +32,7 @@ public class SingleProblem {
 	@Column
 	private Long problemId;
 
+	@Setter
 	private String singleProblemName;
 
 	private Long memberId;

--- a/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/service/SingleProblemUpdateService.java
+++ b/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/service/SingleProblemUpdateService.java
@@ -1,0 +1,37 @@
+package kr.co.mathrank.domain.problem.single.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.domain.problem.single.dto.SingleProblemUpdateCommand;
+import kr.co.mathrank.domain.problem.single.entity.SingleProblem;
+import kr.co.mathrank.domain.problem.single.exception.CannotFindSingleProblemException;
+import kr.co.mathrank.domain.problem.single.repository.SingleProblemRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@Validated
+@RequiredArgsConstructor
+public class SingleProblemUpdateService {
+	private final SingleProblemRepository singleProblemRepository;
+
+	@Transactional
+	public void update(@NotNull @Valid final SingleProblemUpdateCommand command) {
+		final SingleProblem singleProblem = findSingleProblem(command.singleProblemId());
+		singleProblem.setSingleProblemName(command.singleProblemName());
+	}
+
+	private SingleProblem findSingleProblem(final Long singleProblemId) {
+		return singleProblemRepository.findById(singleProblemId)
+			.orElseThrow(() -> {
+				log.info("[SingleProblemUpdateService.update] cannot find single problem - singleProblemId: {}",
+					singleProblemId);
+				return new CannotFindSingleProblemException();
+			});
+	}
+}

--- a/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/service/SingleProblemUpdateService.java
+++ b/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/service/SingleProblemUpdateService.java
@@ -8,7 +8,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import kr.co.mathrank.common.event.EventPayload;
 import kr.co.mathrank.common.outbox.TransactionalOutboxPublisher;
-import kr.co.mathrank.domain.problem.single.dto.SingleProblemUpdateCommand;
+import kr.co.mathrank.domain.problem.single.dto.SingleProblemNameUpdateCommand;
 import kr.co.mathrank.domain.problem.single.entity.SingleProblem;
 import kr.co.mathrank.domain.problem.single.exception.CannotFindSingleProblemException;
 import kr.co.mathrank.domain.problem.single.repository.SingleProblemRepository;
@@ -24,7 +24,7 @@ public class SingleProblemUpdateService {
 	private final TransactionalOutboxPublisher outboxPublisher;
 
 	@Transactional
-	public void update(@NotNull @Valid final SingleProblemUpdateCommand command) {
+	public void update(@NotNull @Valid final SingleProblemNameUpdateCommand command) {
 		final SingleProblem singleProblem = findSingleProblem(command.singleProblemId());
 		singleProblem.setSingleProblemName(command.singleProblemName());
 		outboxPublisher.publish("single-problem-name-updated", SingleProblemUpdatedEventPayload.from(singleProblem));

--- a/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/service/SingleProblemUpdateService.java
+++ b/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/service/SingleProblemUpdateService.java
@@ -6,6 +6,8 @@ import org.springframework.validation.annotation.Validated;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.common.event.EventPayload;
+import kr.co.mathrank.common.outbox.TransactionalOutboxPublisher;
 import kr.co.mathrank.domain.problem.single.dto.SingleProblemUpdateCommand;
 import kr.co.mathrank.domain.problem.single.entity.SingleProblem;
 import kr.co.mathrank.domain.problem.single.exception.CannotFindSingleProblemException;
@@ -19,11 +21,13 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class SingleProblemUpdateService {
 	private final SingleProblemRepository singleProblemRepository;
+	private final TransactionalOutboxPublisher outboxPublisher;
 
 	@Transactional
 	public void update(@NotNull @Valid final SingleProblemUpdateCommand command) {
 		final SingleProblem singleProblem = findSingleProblem(command.singleProblemId());
 		singleProblem.setSingleProblemName(command.singleProblemName());
+		outboxPublisher.publish("single-problem-name-updated", SingleProblemUpdatedEventPayload.from(singleProblem));
 	}
 
 	private SingleProblem findSingleProblem(final Long singleProblemId) {
@@ -33,5 +37,21 @@ public class SingleProblemUpdateService {
 					singleProblemId);
 				return new CannotFindSingleProblemException();
 			});
+	}
+
+	record SingleProblemUpdatedEventPayload(
+		Long singleProblemId,
+		String singleProblemName,
+		Long problemId,
+		Long memberId
+	) implements EventPayload {
+		public static SingleProblemUpdatedEventPayload from(final SingleProblem singleProblem) {
+			return new SingleProblemUpdatedEventPayload(
+				singleProblem.getId(),
+				singleProblem.getSingleProblemName(),
+				singleProblem.getProblemId(),
+				singleProblem.getMemberId()
+			);
+		}
 	}
 }

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemReadModelNameUpdateCommand.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemReadModelNameUpdateCommand.java
@@ -1,0 +1,12 @@
+package kr.co.mathrank.domain.problem.single.read.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record SingleProblemReadModelNameUpdateCommand(
+	@NotNull
+	Long singleProblemId,
+	@NotBlank
+	String singleProblemName
+) {
+}

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemUpdateService.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemUpdateService.java
@@ -67,7 +67,7 @@ public class SingleProblemUpdateService {
 	public void updateSingleProblemName(@NotNull @Valid final SingleProblemReadModelNameUpdateCommand command) {
 		final SingleProblemReadModel model = singleProblemReadModelRepository.findByIdForUpdate(command.singleProblemId())
 			.orElseThrow(() -> {
-				log.warn("[SingleProblemUpdateService.updateSingleProblemName] cannot find problemId: {}", command.singleProblemId());
+				log.warn("[SingleProblemUpdateService.updateSingleProblemName] cannot find single problem - singleProblemId {}", command.singleProblemId());
 				return new CannotFoundProblemException();
 			});
 		model.setSingleProblemName(command.singleProblemName());

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemUpdateService.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemUpdateService.java
@@ -7,6 +7,7 @@ import org.springframework.validation.annotation.Validated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemAttemptStatsUpdateCommand;
+import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelNameUpdateCommand;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelUpdateCommand;
 import kr.co.mathrank.domain.problem.single.read.entity.SingleProblemReadModel;
 import kr.co.mathrank.domain.problem.single.read.entity.SingleProblemSolver;
@@ -60,6 +61,17 @@ public class SingleProblemUpdateService {
 			return;
 		}
 		log.info("[SingleProblemUpdateService.updateProblemInfo] read model not updated: {}", command);
+	}
+
+	@Transactional
+	public void updateSingleProblemName(@NotNull @Valid final SingleProblemReadModelNameUpdateCommand command) {
+		final SingleProblemReadModel model = singleProblemReadModelRepository.findByProblemIdForUpdate(command.singleProblemId())
+			.orElseThrow(() -> {
+				log.warn("[SingleProblemUpdateService.updateSingleProblemName] cannot find problemId: {}", command.singleProblemId());
+				return new CannotFoundProblemException();
+			});
+		model.setSingleProblemName(command.singleProblemName());
+		log.info("[SingleProblemUpdateService.updateSingleProblemName] read model updated: {}", command);
 	}
 
 	/**

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemUpdateService.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemUpdateService.java
@@ -65,7 +65,7 @@ public class SingleProblemUpdateService {
 
 	@Transactional
 	public void updateSingleProblemName(@NotNull @Valid final SingleProblemReadModelNameUpdateCommand command) {
-		final SingleProblemReadModel model = singleProblemReadModelRepository.findByProblemIdForUpdate(command.singleProblemId())
+		final SingleProblemReadModel model = singleProblemReadModelRepository.findByIdForUpdate(command.singleProblemId())
 			.orElseThrow(() -> {
 				log.warn("[SingleProblemUpdateService.updateSingleProblemName] cannot find problemId: {}", command.singleProblemId());
 				return new CannotFoundProblemException();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can rename single problem titles via a new API endpoint.
  * Title updates are validated to ensure non-empty names.
  * Renames are propagated across the system and read models automatically.
  * Updates are processed reliably with event-driven synchronization.
  * Admin authorization is required for all title modifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->