### PR TITLE
feat(oauth): 회원탈퇴시, oauth 연동해제 되도록 수정

### DIFF
--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/AccessTokenResponse.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/AccessTokenResponse.java
@@ -2,6 +2,7 @@ package kr.co.mathrank.domain.auth.client;
 
 record AccessTokenResponse(
 	String token_type,
-	String access_token
+	String access_token,
+	String refresh_token
 ) {
 }

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/GoogleInfoResponse.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/GoogleInfoResponse.java
@@ -6,6 +6,6 @@ public record GoogleInfoResponse(
 ) implements MemberInfoResponse{
 	@Override
 	public MemberInfo toInfo() {
-		return new MemberInfo(id(), given_name());
+		return new MemberInfo(id(), given_name(),null, null);
 	}
 }

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/GoogleOAuthClient.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/GoogleOAuthClient.java
@@ -28,7 +28,10 @@ class GoogleOAuthClient implements OAuthClientHandler {
 
 	@Override
 	public MemberInfoResponse getMemberInfo(OAuthLoginCommand command) {
-		return getInfo(getAccessToken(command).access_token());
+		final AccessTokenResponse token = getAccessToken(command);
+		final MemberInfoResponse infoResponse = getInfo(token.access_token());
+
+		return new MemberInfoRefreshTokenAdapter(infoResponse.toInfo(), token.refresh_token(), token.token_type());
 	}
 
 	private GoogleInfoResponse getInfo(final String accessToken) {

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/GoogleOAuthClient.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/GoogleOAuthClient.java
@@ -15,8 +15,11 @@ class GoogleOAuthClient implements OAuthClientHandler {
 
 	// 토큰 URL
 	private static final String TOKEN_URL = "https://oauth2.googleapis.com/token";
+	// 토큰 폐기 URL
+	private static final String TOKEN_REVOKE_URL = "https://oauth2.googleapis.com/revoke";
 	// 사용자 정보 조회 URL
 	private static final String INFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
+
 
 	private final RestClient tokenClient = RestClient.builder()
 		.baseUrl(TOKEN_URL)
@@ -24,6 +27,10 @@ class GoogleOAuthClient implements OAuthClientHandler {
 
 	private final RestClient infoClient = RestClient.builder()
 		.baseUrl(INFO_URL)
+		.build();
+
+	private final RestClient revokeClient = RestClient.builder()
+		.baseUrl(TOKEN_REVOKE_URL)
 		.build();
 
 	@Override
@@ -58,5 +65,17 @@ class GoogleOAuthClient implements OAuthClientHandler {
 	@Override
 	public boolean supports(OAuthProvider provider) {
 		return OAuthProvider.GOOGLE.equals(provider);
+	}
+
+	// 구글은 refreshToken 만으로도 삭제 가능
+	// https://developers.google.com/identity/protocols/oauth2/web-server?hl=ko
+	@Override
+	public boolean revoke(String refreshToken) {
+		return revokeClient.post()
+			.uri("token", refreshToken)
+			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+			.retrieve()
+			.toBodilessEntity()
+			.getStatusCode().is2xxSuccessful();
 	}
 }

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/GoogleOAuthClient.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/GoogleOAuthClient.java
@@ -72,7 +72,10 @@ class GoogleOAuthClient implements OAuthClientHandler {
 	@Override
 	public boolean revoke(String refreshToken) {
 		return revokeClient.post()
-			.uri("token", refreshToken)
+			.uri(uriBuilder -> uriBuilder
+				.queryParam("token", refreshToken)
+				.build()
+			)
 			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 			.retrieve()
 			.toBodilessEntity()

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/KakaoMemberInfoResponse.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/KakaoMemberInfoResponse.java
@@ -21,7 +21,7 @@ record KakaoMemberInfoResponse(
 
 	@Override
 	public MemberInfo toInfo() {
-		return new MemberInfo(String.valueOf(id), getNickName());
+		return new MemberInfo(String.valueOf(id), getNickName(),null, null);
 	}
 
 	record Account (

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/KakaoOAuthClient.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/KakaoOAuthClient.java
@@ -18,6 +18,10 @@ class KakaoOAuthClient implements OAuthClientHandler{
 		.baseUrl("https://kauth.kakao.com/oauth/token")
 		.build();
 
+	private final RestClient tokenUnlinkClient = RestClient.builder()
+		.baseUrl("https://kapi.kakao.com/v1/user/unlink")
+		.build();
+
 	// https://kapi.kakao.com/v2/user/me
 	// 사용자 정보 조회
 	private final RestClient infoClient = RestClient.builder()
@@ -57,5 +61,41 @@ class KakaoOAuthClient implements OAuthClientHandler{
 	@Override
 	public boolean supports(OAuthProvider provider) {
 		return provider == OAuthProvider.KAKAO;
+	}
+
+	@Override
+	public boolean revoke(final String refreshToken) {
+		final AccessTokenResponse token = refreshByRefreshToken(refreshToken);
+		return revokeByAccessToken(token.access_token());
+	}
+
+	private boolean revokeByAccessToken(final String accessToken) {
+		return tokenUnlinkClient.post()
+			.header(HttpHeaders.AUTHORIZATION, "Bearer %s".formatted(accessToken))
+			.retrieve()
+			.body(KakaoRevokeResponse.class)
+			.succeed();
+	}
+
+	private AccessTokenResponse refreshByRefreshToken(final String refreshToken) {
+		return tokenClient.post()
+			.uri(uriBuilder -> uriBuilder
+				.queryParam("grant_type", kakaoConfiguration.getGrantType())
+				.queryParam("client_id", kakaoConfiguration.getClientId())
+				.queryParam("refresh_token", refreshToken)
+				.queryParam("client_secret", kakaoConfiguration.getClientSecret())
+				.build()
+			)
+			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+			.retrieve()
+			.body(AccessTokenResponse.class);
+	}
+
+	private record KakaoRevokeResponse(
+		String id
+	) {
+		boolean succeed() {
+			return id != null;
+		}
 	}
 }

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/KakaoOAuthClient.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/KakaoOAuthClient.java
@@ -80,7 +80,7 @@ class KakaoOAuthClient implements OAuthClientHandler{
 	private AccessTokenResponse refreshByRefreshToken(final String refreshToken) {
 		return tokenClient.post()
 			.uri(uriBuilder -> uriBuilder
-				.queryParam("grant_type", kakaoConfiguration.getGrantType())
+				.queryParam("grant_type", "refresh_token")
 				.queryParam("client_id", kakaoConfiguration.getClientId())
 				.queryParam("refresh_token", refreshToken)
 				.queryParam("client_secret", kakaoConfiguration.getClientSecret())

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/KakaoOAuthClient.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/KakaoOAuthClient.java
@@ -26,7 +26,10 @@ class KakaoOAuthClient implements OAuthClientHandler{
 
 	@Override
 	public MemberInfoResponse getMemberInfo(OAuthLoginCommand command) {
-		return getKakaoInfoResponse(getAccessToken(command.code()).access_token());
+		final AccessTokenResponse token = getAccessToken(command.code());
+		final MemberInfoResponse infoResponse = getKakaoInfoResponse(token.access_token());
+
+		return new MemberInfoRefreshTokenAdapter(infoResponse.toInfo(), token.refresh_token(), token.token_type());
 	}
 
 	public AccessTokenResponse getAccessToken(final String code) {

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/MemberInfo.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/MemberInfo.java
@@ -2,6 +2,8 @@ package kr.co.mathrank.domain.auth.client;
 
 public record MemberInfo(
 	String memberId,
-	String nickName
+	String nickName,
+	String refreshToken,
+	String tokenType
 ) {
 }

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/MemberInfoRefreshTokenAdapter.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/MemberInfoRefreshTokenAdapter.java
@@ -1,0 +1,14 @@
+package kr.co.mathrank.domain.auth.client;
+
+public record MemberInfoRefreshTokenAdapter(MemberInfo memberInfo, String refreshToken, String tokenType)
+	implements MemberInfoResponse {
+	@Override
+	public MemberInfo toInfo() {
+		return new MemberInfo(
+			memberInfo.memberId(),
+			memberInfo.nickName(),
+			refreshToken,
+			tokenType
+		);
+	}
+}

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverMemberInfoResponse.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverMemberInfoResponse.java
@@ -5,7 +5,7 @@ record NaverMemberInfoResponse(
 ) implements MemberInfoResponse {
 	@Override
 	public MemberInfo toInfo() {
-		return new MemberInfo(response.id(), response.nickname());
+		return new MemberInfo(response.id(), response.nickname(),null, null);
 	}
 
 	record NaverResponse(

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverOAuthClient.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverOAuthClient.java
@@ -28,7 +28,10 @@ class NaverOAuthClient implements OAuthClientHandler {
 
 	@Override
 	public MemberInfoResponse getMemberInfo(OAuthLoginCommand command) {
-		return getUserInfo(getAccessToken(command).access_token());
+		final AccessTokenResponse token = getAccessToken(command);
+		final MemberInfoResponse infoResponse = getUserInfo(token.access_token());
+		
+		return new MemberInfoRefreshTokenAdapter(infoResponse.toInfo(), token.refresh_token(), token.token_type());
 	}
 
 	private AccessTokenResponse getAccessToken(final OAuthLoginCommand command) {

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverOAuthClient.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverOAuthClient.java
@@ -57,7 +57,49 @@ class NaverOAuthClient implements OAuthClientHandler {
 	}
 
 	@Override
+	public boolean revoke(final String refreshToken) {
+		final AccessTokenResponse token = refreshAccessToken(refreshToken);
+
+		return tokenClient.post()
+			.uri(uriBuilder -> uriBuilder
+				.queryParam("client_id", naverConfiguration.getClientId())
+				.queryParam("client_secret", naverConfiguration.getClientSecret())
+				.queryParam("access_token", token.access_token())
+				.queryParam("grant_type", "delete")
+				.build())
+			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+			.retrieve()
+			.body(TokenRevokeResponse.class)
+			.succeeded();
+	}
+
+	private AccessTokenResponse refreshAccessToken(String refreshToken) {
+		return tokenClient.post()
+			.uri(uriBuilder -> uriBuilder
+				.queryParam("grant_type", "refresh_token")
+				.queryParam("client_id", naverConfiguration.getClientId())
+				.queryParam("client_secret", naverConfiguration.getClientSecret())
+				.queryParam("refresh_token", refreshToken)
+				.build())
+			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+			.retrieve()
+			.body(AccessTokenResponse.class);
+	}
+
+	@Override
 	public boolean supports(OAuthProvider provider) {
 		return OAuthProvider.NAVER.equals(provider);
+	}
+
+	record TokenRevokeResponse(
+		String success
+	) {
+		boolean succeeded() {
+			if (success == null) {
+				return false;
+			}
+
+			return success.equals("success");
+		}
 	}
 }

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverOAuthClient.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverOAuthClient.java
@@ -92,14 +92,14 @@ class NaverOAuthClient implements OAuthClientHandler {
 	}
 
 	record TokenRevokeResponse(
-		String success
+		String result
 	) {
 		boolean succeeded() {
-			if (success == null) {
+			if (result == null) {
 				return false;
 			}
 
-			return success.equals("success");
+			return result.equals("success");
 		}
 	}
 }

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/OAuthClientHandler.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/OAuthClientHandler.java
@@ -6,4 +6,5 @@ import kr.co.mathrank.domain.auth.entity.OAuthProvider;
 interface OAuthClientHandler {
 	MemberInfoResponse getMemberInfo(final OAuthLoginCommand command);
 	boolean supports(final OAuthProvider provider);
+	boolean revoke(final String refreshToken);
 }

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/OAuthClientManager.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/OAuthClientManager.java
@@ -9,6 +9,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import kr.co.mathrank.domain.auth.dto.OAuthLoginCommand;
+import kr.co.mathrank.domain.auth.entity.Member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -26,6 +27,17 @@ public class OAuthClientManager {
 			.map(oAuthClientHandler -> oAuthClientHandler.getMemberInfo(command))
 			.map(MemberInfoResponse::toInfo)
 			.orElseThrow();
+	}
+
+	public boolean revoke(final Member member) {
+		return handlers.stream()
+			.filter(oAuthClientHandler -> oAuthClientHandler.supports(member.getOAuthInfo().getOAuthProvider()))
+			.findAny()
+			.map(oAuthClientHandler -> oAuthClientHandler.revoke(member.getOAuthInfo().getOAuthRefreshToken()))
+			.orElseGet(() -> {
+				log.info("[OAuthClientManager.revoke] its not a oauth registered user - memberId: {}", member.getId());
+				return true;
+			});
 	}
 
 	@PostConstruct

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/entity/Member.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/entity/Member.java
@@ -82,11 +82,17 @@ public class Member {
 	}
 
 	public static Member fromOAuth(final Long id, final String oAuthId, final OAuthProvider provider,
-		final String nickName, final Role role) {
+		final String oAuthRefreshToken,
+		final String oAuthTokenType,
+		final String nickName,
+		final Role role
+	) {
 		final Member member = new Member();
 		member.id = id;
 		member.oAuthInfo.setOAuthUserId(oAuthId);
 		member.oAuthInfo.setOAuthProvider(provider);
+		member.oAuthInfo.setOAuthRefreshToken(oAuthRefreshToken);
+		member.oAuthInfo.setTokenType(oAuthTokenType);
 		member.name = nickName;
 		member.role = role;
 

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/entity/OAuthInfo.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/entity/OAuthInfo.java
@@ -17,4 +17,10 @@ public class OAuthInfo {
 
 	@Column(name = "oauth_user_id")
 	private String oAuthUserId;
+
+	@Column(name = "oauth_user_refresh_token")
+	private String oAuthRefreshToken;
+
+	@Column(name = "oauth_user_refresh_token_type")
+	private String tokenType;
 }

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/exception/UnRegisterMemberException.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/exception/UnRegisterMemberException.java
@@ -1,0 +1,7 @@
+package kr.co.mathrank.domain.auth.exception;
+
+public class UnRegisterMemberException extends AuthException {
+	public UnRegisterMemberException(String message) {
+		super(1007, message);
+	}
+}

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/service/MemberDeleteService.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/service/MemberDeleteService.java
@@ -5,6 +5,7 @@ import org.springframework.validation.annotation.Validated;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.domain.auth.client.OAuthClientManager;
 import kr.co.mathrank.domain.auth.dto.MemberDeleteCommand;
 import kr.co.mathrank.domain.auth.entity.Member;
 import kr.co.mathrank.domain.auth.exception.CannotFoundMemberException;
@@ -18,10 +19,13 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class MemberDeleteService {
 	private final MemberRepository memberRepository;
+	private final OAuthClientManager oAuthClientManager;
 
 	public void delete(@NotNull @Valid final MemberDeleteCommand command) {
 		final Member member = getMember(command.targetMemberId());
 		memberRepository.delete(member);
+		oAuthClientManager.revoke(member);
+
 		log.info("[MemberDeleteService.delete] member delete success - memberId: {}", command.targetMemberId());
 	}
 

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/service/MemberDeleteService.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/service/MemberDeleteService.java
@@ -1,6 +1,7 @@
 package kr.co.mathrank.domain.auth.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
 import jakarta.validation.Valid;
@@ -9,6 +10,7 @@ import kr.co.mathrank.domain.auth.client.OAuthClientManager;
 import kr.co.mathrank.domain.auth.dto.MemberDeleteCommand;
 import kr.co.mathrank.domain.auth.entity.Member;
 import kr.co.mathrank.domain.auth.exception.CannotFoundMemberException;
+import kr.co.mathrank.domain.auth.exception.UnRegisterMemberException;
 import kr.co.mathrank.domain.auth.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,10 +23,16 @@ public class MemberDeleteService {
 	private final MemberRepository memberRepository;
 	private final OAuthClientManager oAuthClientManager;
 
+	@Transactional
 	public void delete(@NotNull @Valid final MemberDeleteCommand command) {
 		final Member member = getMember(command.targetMemberId());
 		memberRepository.delete(member);
-		oAuthClientManager.revoke(member);
+
+		// oauth 삭제 실패했을 경우
+		if (oAuthClientManager.revoke(member)) {
+			log.info("[MemberDeleteService.delete] failed to revoke OAuth client for member - memberId: {}", member.getId());
+			throw new UnRegisterMemberException("oauth 연동 해제중 에러 발생했습니다. 잠시 후 다시 시도해주세요");
+		}
 
 		log.info("[MemberDeleteService.delete] member delete success - memberId: {}", command.targetMemberId());
 	}

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/service/MemberDeleteService.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/service/MemberDeleteService.java
@@ -29,7 +29,7 @@ public class MemberDeleteService {
 		memberRepository.delete(member);
 
 		// oauth 삭제 실패했을 경우
-		if (oAuthClientManager.revoke(member)) {
+		if (!oAuthClientManager.revoke(member)) {
 			log.info("[MemberDeleteService.delete] failed to revoke OAuth client for member - memberId: {}", member.getId());
 			throw new UnRegisterMemberException("oauth 연동 해제중 에러 발생했습니다. 잠시 후 다시 시도해주세요");
 		}

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/service/OAuthLoginService.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/service/OAuthLoginService.java
@@ -15,6 +15,7 @@ import kr.co.mathrank.domain.auth.dto.JwtOAuthLoginResult;
 import kr.co.mathrank.domain.auth.dto.MemberInfoCompleteCommand;
 import kr.co.mathrank.domain.auth.dto.OAuthLoginCommand;
 import kr.co.mathrank.domain.auth.entity.Member;
+import kr.co.mathrank.domain.auth.entity.OAuthInfo;
 import kr.co.mathrank.domain.auth.exception.CannotFoundMemberException;
 import kr.co.mathrank.domain.auth.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -49,6 +50,7 @@ public class OAuthLoginService {
 				return newMember;
 			});
 
+		refreshTokenInfo(memberInfo, member);
 		log.info("[OAuthLoginService.login] member login success with oAuth - memberId: {}, oAuthProvider: {}", member.getId(), member.getOAuthInfo().getOAuthProvider());
 		// 사용자의 등록 지연 여부를 함께 응답한다.
 		return JwtOAuthLoginResult.from(jwtLogin(member), member.getPending());
@@ -76,5 +78,10 @@ public class OAuthLoginService {
 
 	private JwtLoginResult jwtLogin(final Member member) {
 		return jwtLoginManager.login(member.getId(), member.getRole(), member.getName());
+	}
+
+	private void refreshTokenInfo(final MemberInfo memberInfo, final Member member) {
+		final OAuthInfo oAuthInfo = member.getOAuthInfo();
+		oAuthInfo.setOAuthRefreshToken(memberInfo.refreshToken());
 	}
 }

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/service/OAuthLoginService.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/service/OAuthLoginService.java
@@ -42,6 +42,7 @@ public class OAuthLoginService {
 				final Long uniqueId = snowflake.nextId();
 
 				final Member newMember = Member.fromOAuth(uniqueId, memberInfo.memberId(), command.provider(),
+					memberInfo.refreshToken(), memberInfo.tokenType(),
 					memberInfo.nickName(), Role.USER);
 				memberRepository.save(newMember);
 				log.info("[OAuthLoginService.login] member registered - memberId: {}, oAuthProvider: {}", uniqueId, command.provider());

--- a/domain/mathrank-auth-domain/src/test/java/kr/co/mathrank/domain/auth/repository/MemberRepositoryTest.java
+++ b/domain/mathrank-auth-domain/src/test/java/kr/co/mathrank/domain/auth/repository/MemberRepositoryTest.java
@@ -23,7 +23,7 @@ class MemberRepositoryTest {
 	@Test
 	void oAuth_제공자와_ID로_조회성공() {
 		final String oAuthId = "12";
-		final Member member = Member.fromOAuth(1L, oAuthId, OAuthProvider.KAKAO, "nickName", Role.USER);
+		final Member member = Member.fromOAuth(1L, oAuthId, OAuthProvider.KAKAO, "testRefreshToken", "testTokenType", "nickName", Role.USER);
 		memberRepository.save(member);
 
 		entityManager.flush();

--- a/domain/mathrank-auth-domain/src/test/java/kr/co/mathrank/domain/auth/service/OAuthLoginServiceTest.java
+++ b/domain/mathrank-auth-domain/src/test/java/kr/co/mathrank/domain/auth/service/OAuthLoginServiceTest.java
@@ -57,7 +57,7 @@ class OAuthLoginServiceTest {
 		final OAuthLoginCommand command = new OAuthLoginCommand("testCode", "testState", kakao);
 
 		final String oAuthId = "12345";
-		final MemberInfo memberInfo = new MemberInfo(oAuthId, "nickName");
+		final MemberInfo memberInfo = new MemberInfo(oAuthId, "nickName", "refreshTOken", "tokenType");
 		// 항상 memberInfo 리턴
 		Mockito.when(oAuthClientManager.getMemberInfo(command)).thenReturn(memberInfo);
 		Mockito.when(jwtLoginManager.login(Mockito.anyLong(), Mockito.any(), Mockito.any()))
@@ -91,7 +91,7 @@ class OAuthLoginServiceTest {
 		final OAuthLoginCommand command = new OAuthLoginCommand("testCode", "testState", kakao);
 
 		final String oAuthId = "12345";
-		final MemberInfo memberInfo = new MemberInfo(oAuthId, "nickName");
+		final MemberInfo memberInfo = new MemberInfo(oAuthId, "nickName", "refreshTOken", "tokenType");
 		// 항상 memberInfo 리턴
 		Mockito.when(oAuthClientManager.getMemberInfo(command)).thenReturn(memberInfo);
 		Mockito.when(jwtLoginManager.login(Mockito.anyLong(), Mockito.any(), Mockito.any()))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OAuth token revocation functionality across all supported providers (Google, Kakao, Naver)
  * Implemented refresh token management in the authentication system
  * Enhanced account deletion to automatically revoke associated OAuth tokens for improved security

<!-- end of auto-generated comment: release notes by coderabbit.ai -->