### PR TITLE
feat(oauth): 이메일 받도록 수정

### DIFF
--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/GoogleInfoResponse.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/GoogleInfoResponse.java
@@ -2,10 +2,11 @@ package kr.co.mathrank.domain.auth.client;
 
 public record GoogleInfoResponse(
 	String id,
-	String given_name
+	String given_name,
+	String email
 ) implements MemberInfoResponse{
 	@Override
 	public MemberInfo toInfo() {
-		return new MemberInfo(id(), given_name(),null, null);
+		return new MemberInfo(id(), given_name(), email(), null, null);
 	}
 }

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/KakaoMemberInfoResponse.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/KakaoMemberInfoResponse.java
@@ -21,14 +21,25 @@ record KakaoMemberInfoResponse(
 
 	@Override
 	public MemberInfo toInfo() {
-		return new MemberInfo(String.valueOf(id), getNickName(),null, null);
+		return new MemberInfo(String.valueOf(id), getNickName(), kakao_account().getEmail(), null, null);
 	}
 
 	record Account (
-		Profile profile
+		Profile profile,
+		Boolean is_email_valid, // 유효한 이메일인지 ( 마스킹 되어 있는지 )
+		Boolean is_email_verified, // 인증된 이메일인지 ( 이메일 인증 완료 됐는지 )
+		String email
 	) {
+		public String getEmail() {
+			if (is_email_valid && is_email_verified) {
+				return email;
+			}
 
+			log.info("[KakaoMemberInfoResponse.getEmail] email is not available - email: {}", this);
+			return null;
+		}
 	}
+
 	record Profile(
 		String nickname
 	) {

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/MemberInfo.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/MemberInfo.java
@@ -3,6 +3,7 @@ package kr.co.mathrank.domain.auth.client;
 public record MemberInfo(
 	String memberId,
 	String nickName,
+	String email,
 	String refreshToken,
 	String tokenType
 ) {

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/MemberInfoRefreshTokenAdapter.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/MemberInfoRefreshTokenAdapter.java
@@ -7,6 +7,7 @@ public record MemberInfoRefreshTokenAdapter(MemberInfo memberInfo, String refres
 		return new MemberInfo(
 			memberInfo.memberId(),
 			memberInfo.nickName(),
+			memberInfo.email(),
 			refreshToken,
 			tokenType
 		);

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverMemberInfoResponse.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverMemberInfoResponse.java
@@ -5,12 +5,13 @@ record NaverMemberInfoResponse(
 ) implements MemberInfoResponse {
 	@Override
 	public MemberInfo toInfo() {
-		return new MemberInfo(response.id(), response.nickname(),null, null);
+		return new MemberInfo(response.id(), response.nickname(), response.email(), null, null);
 	}
 
 	record NaverResponse(
 		String nickname,
-		String id
+		String id,
+		String email
 	) {
 	}
 }

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/entity/Member.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/entity/Member.java
@@ -49,6 +49,8 @@ public class Member {
 
 	private String password;
 
+	private String email;
+
 	@Embedded
 	private final OAuthInfo oAuthInfo = new OAuthInfo();
 
@@ -85,7 +87,8 @@ public class Member {
 		final String oAuthRefreshToken,
 		final String oAuthTokenType,
 		final String nickName,
-		final Role role
+		final Role role,
+		final String email
 	) {
 		final Member member = new Member();
 		member.id = id;
@@ -95,6 +98,7 @@ public class Member {
 		member.oAuthInfo.setTokenType(oAuthTokenType);
 		member.name = nickName;
 		member.role = role;
+		member.email = email;
 
 		return member;
 	}

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/service/OAuthLoginService.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/service/OAuthLoginService.java
@@ -44,7 +44,7 @@ public class OAuthLoginService {
 
 				final Member newMember = Member.fromOAuth(uniqueId, memberInfo.memberId(), command.provider(),
 					memberInfo.refreshToken(), memberInfo.tokenType(),
-					memberInfo.nickName(), Role.USER);
+					memberInfo.nickName(), Role.USER, memberInfo.email());
 				memberRepository.save(newMember);
 				log.info("[OAuthLoginService.login] member registered - memberId: {}, oAuthProvider: {}", uniqueId, command.provider());
 				return newMember;

--- a/domain/mathrank-auth-domain/src/test/java/kr/co/mathrank/domain/auth/repository/MemberRepositoryTest.java
+++ b/domain/mathrank-auth-domain/src/test/java/kr/co/mathrank/domain/auth/repository/MemberRepositoryTest.java
@@ -23,7 +23,7 @@ class MemberRepositoryTest {
 	@Test
 	void oAuth_제공자와_ID로_조회성공() {
 		final String oAuthId = "12";
-		final Member member = Member.fromOAuth(1L, oAuthId, OAuthProvider.KAKAO, "testRefreshToken", "testTokenType", "nickName", Role.USER);
+		final Member member = Member.fromOAuth(1L, oAuthId, OAuthProvider.KAKAO, "testRefreshToken", "testTokenType", "nickName", Role.USER, "email");
 		memberRepository.save(member);
 
 		entityManager.flush();

--- a/domain/mathrank-auth-domain/src/test/java/kr/co/mathrank/domain/auth/service/OAuthLoginServiceTest.java
+++ b/domain/mathrank-auth-domain/src/test/java/kr/co/mathrank/domain/auth/service/OAuthLoginServiceTest.java
@@ -57,7 +57,7 @@ class OAuthLoginServiceTest {
 		final OAuthLoginCommand command = new OAuthLoginCommand("testCode", "testState", kakao);
 
 		final String oAuthId = "12345";
-		final MemberInfo memberInfo = new MemberInfo(oAuthId, "nickName", "refreshTOken", "tokenType");
+		final MemberInfo memberInfo = new MemberInfo(oAuthId, "nickName", "email", "refreshTOken", "tokenType");
 		// 항상 memberInfo 리턴
 		Mockito.when(oAuthClientManager.getMemberInfo(command)).thenReturn(memberInfo);
 		Mockito.when(jwtLoginManager.login(Mockito.anyLong(), Mockito.any(), Mockito.any()))
@@ -91,7 +91,7 @@ class OAuthLoginServiceTest {
 		final OAuthLoginCommand command = new OAuthLoginCommand("testCode", "testState", kakao);
 
 		final String oAuthId = "12345";
-		final MemberInfo memberInfo = new MemberInfo(oAuthId, "nickName", "refreshTOken", "tokenType");
+		final MemberInfo memberInfo = new MemberInfo(oAuthId, "nickName", "email", "refreshTOken", "tokenType");
 		// 항상 memberInfo 리턴
 		Mockito.when(oAuthClientManager.getMemberInfo(command)).thenReturn(memberInfo);
 		Mockito.when(jwtLoginManager.login(Mockito.anyLong(), Mockito.any(), Mockito.any()))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Email addresses from OAuth providers are now automatically captured during authentication. When signing in with Google, Kakao, or Naver, your email is linked to your account profile for enhanced account management and communication capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->