### PR TITLE
fix(oauth): 로그인 마다 refresh token 갱신되던 오류 수정

### DIFF
--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/service/OAuthLoginService.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/service/OAuthLoginService.java
@@ -50,7 +50,6 @@ public class OAuthLoginService {
 				return newMember;
 			});
 
-		refreshTokenInfo(memberInfo, member);
 		log.info("[OAuthLoginService.login] member login success with oAuth - memberId: {}, oAuthProvider: {}", member.getId(), member.getOAuthInfo().getOAuthProvider());
 		// 사용자의 등록 지연 여부를 함께 응답한다.
 		return JwtOAuthLoginResult.from(jwtLogin(member), member.getPending());
@@ -78,10 +77,5 @@ public class OAuthLoginService {
 
 	private JwtLoginResult jwtLogin(final Member member) {
 		return jwtLoginManager.login(member.getId(), member.getRole(), member.getName());
-	}
-
-	private void refreshTokenInfo(final MemberInfo memberInfo, final Member member) {
-		final OAuthInfo oAuthInfo = member.getOAuthInfo();
-		oAuthInfo.setOAuthRefreshToken(memberInfo.refreshToken());
 	}
 }


### PR DESCRIPTION
- 수정 대상
  - 로그인 마다 refresh token 을 갱신하는 로직이였음.
  - 구글 oauth에서, 회원가입 이후의 로그인에서 refresh token이 오지 않음에 따라
  - 서버에 저장되는 refresh token이 null로 변경되는 오류 존재.
  - 이에 따라 회원 탈퇴 시, refresh token 이 null임으로 인해 실패
- 해결 결과
  - 따라서, 로그인마다 refresh token 갱신하던 로직 삭제
  - 첫 회원가입 시에 발급받은 refresh token으로 회원탈퇴에 적용 ( 구글의 경우 )

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified OAuth login flow by removing token refresh during authentication. Login functionality remains unchanged, but OAuth tokens will no longer be updated upon each login attempt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->