### PR TITLE
fix(oauth): naver 로그인 해지 api 요청에 service_provider 파라미터 추가

### DIFF
--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverOAuthClient.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverOAuthClient.java
@@ -66,6 +66,7 @@ class NaverOAuthClient implements OAuthClientHandler {
 				.queryParam("client_secret", naverConfiguration.getClientSecret())
 				.queryParam("access_token", token.access_token())
 				.queryParam("grant_type", "delete")
+				.queryParam("service_provider", "NAVER")
 				.build())
 			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 			.retrieve()


### PR DESCRIPTION
https://developers.naver.com/forum/posts/37512

- `Token Revocation` service_provider 필수였음
- 왜 문서화 안되있음? 네이버 어이없음!
- 두번째 이미지에 부재!!!!!

<img width="494" height="724" alt="스크린샷 2025-11-13 오후 3 10 49" src="https://github.com/user-attachments/assets/8a5b0482-34a6-4ed8-9405-8ebba43a308b" />


<img width="492" height="566" alt="스크린샷 2025-11-13 오후 3 14 26" src="https://github.com/user-attachments/assets/66eaeaf5-d9b5-4cc4-a690-6b997b798fd1" />
