### PR TITLE
fix(oauth): naver oauth token revocation에서 인코딩으로 인한 에러 수정

### DIFF
--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverOAuthClient.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverOAuthClient.java
@@ -1,6 +1,7 @@
 package kr.co.mathrank.domain.auth.client;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -67,7 +68,7 @@ class NaverOAuthClient implements OAuthClientHandler {
 			.uri(uriBuilder -> uriBuilder
 				.queryParam("client_id", naverConfiguration.getClientId())
 				.queryParam("client_secret", naverConfiguration.getClientSecret())
-				.queryParam("access_token", UriUtils.encode(token.access_token(), Charset.defaultCharset()))
+				.queryParam("access_token", UriUtils.encode(token.access_token(), StandardCharsets.UTF_8))
 				.queryParam("grant_type", "delete")
 				.queryParam("service_provider", "NAVER")
 				.build())

--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverOAuthClient.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/NaverOAuthClient.java
@@ -1,8 +1,11 @@
 package kr.co.mathrank.domain.auth.client;
 
+import java.nio.charset.Charset;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriUtils;
 
 import kr.co.mathrank.domain.auth.dto.OAuthLoginCommand;
 import kr.co.mathrank.domain.auth.entity.OAuthProvider;
@@ -64,7 +67,7 @@ class NaverOAuthClient implements OAuthClientHandler {
 			.uri(uriBuilder -> uriBuilder
 				.queryParam("client_id", naverConfiguration.getClientId())
 				.queryParam("client_secret", naverConfiguration.getClientSecret())
-				.queryParam("access_token", token.access_token())
+				.queryParam("access_token", UriUtils.encode(token.access_token(), Charset.defaultCharset()))
 				.queryParam("grant_type", "delete")
 				.queryParam("service_provider", "NAVER")
 				.build())

--- a/domain/mathrank-auth-domain/src/test/java/kr/co/mathrank/domain/auth/util/UriUtilEncodeTest.java
+++ b/domain/mathrank-auth-domain/src/test/java/kr/co/mathrank/domain/auth/util/UriUtilEncodeTest.java
@@ -1,0 +1,15 @@
+package kr.co.mathrank.domain.auth.util;
+
+import java.nio.charset.Charset;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.util.UriUtils;
+
+class UriUtilEncodeTest {
+	@Test
+	void plus_문자_인코딩_테스트() {
+		Assertions.assertNotEquals("+", UriUtils.encode("+", Charset.defaultCharset()));
+		Assertions.assertEquals("+", UriUtils.decode("+", Charset.defaultCharset()));
+	}
+}

--- a/domain/mathrank-auth-domain/src/test/java/kr/co/mathrank/domain/auth/util/UriUtilEncodeTest.java
+++ b/domain/mathrank-auth-domain/src/test/java/kr/co/mathrank/domain/auth/util/UriUtilEncodeTest.java
@@ -1,6 +1,7 @@
 package kr.co.mathrank.domain.auth.util;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -9,7 +10,7 @@ import org.springframework.web.util.UriUtils;
 class UriUtilEncodeTest {
 	@Test
 	void plus_문자_인코딩_테스트() {
-		Assertions.assertNotEquals("+", UriUtils.encode("+", Charset.defaultCharset()));
-		Assertions.assertEquals("+", UriUtils.decode("+", Charset.defaultCharset()));
+		Assertions.assertNotEquals("+", UriUtils.encode("+", StandardCharsets.UTF_8));
+		Assertions.assertEquals("+", UriUtils.decode("+", StandardCharsets.UTF_8));
 	}
 }


### PR DESCRIPTION
## 문제
query param으로 전달되는 access token에 `+` 문자가 존재할 시, 
네이버 oauth 서버의 디코딩 과정에서 access token의 `+`이 공백으로 치환됨.

이에 따라 토큰 폐기 실패하는 문제가 있었음.

```
ex) 
원본 access token: `aaa+aaa`
디코딩 된 access token: `aaa aaa`

-> `aaa+aaa`을 삭제해야 하나, `aaa aaa` 삭제 처리
따라서 폐기 실패
```

## 해결
`RestClient`에서 당연히 인코딩 처리해줄줄 알았으나, 
문서 내용을 읽어보니, ASCII 위반 문자만 개별적으로 인코딩하도록 함 ㅠ
+ 문자 또한 ASCII에 포함되어 있음으로, 인코딩하지 않았음 

-> UTF-8인코딩 후, 퍼센트 인코딩으로 해결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth token revocation to properly encode special characters in authentication credentials when sending requests to the authentication server.

* **Tests**
  * Added test coverage to validate character encoding behavior in URI parameters, with focus on correct handling of special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->