### PR TITLE
feat(lazy-connection): lazyConnectionDataSourceProxy 빈 통해 커넥션 점유기간 최소화

### DIFF
--- a/app/api/monolith-api/build.gradle
+++ b/app/api/monolith-api/build.gradle
@@ -41,4 +41,5 @@ dependencies {
     implementation project(':app:consumer:mathrank-contents-consumer-monolith')
 
     implementation project(':common:mathrank-cache-caffeine')
+    implementation project(':common:mathrank-lazy-connection')
 }

--- a/common/mathrank-lazy-connection/build.gradle
+++ b/common/mathrank-lazy-connection/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+}

--- a/common/mathrank-lazy-connection/src/main/java/kr/co/mathrank/common/lazyconnection/LazyConnectionDataSourceProxyConfiguration.java
+++ b/common/mathrank-lazy-connection/src/main/java/kr/co/mathrank/common/lazyconnection/LazyConnectionDataSourceProxyConfiguration.java
@@ -1,0 +1,28 @@
+package kr.co.mathrank.common.lazyconnection;
+
+import javax.sql.DataSource;
+import javax.xml.crypto.Data;
+
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+import com.zaxxer.hikari.HikariDataSource;
+
+@Configuration
+class LazyConnectionDataSourceProxyConfiguration {
+	@Bean
+	HikariDataSource hikariDataSource(final DataSourceProperties dataSourceProperties) {
+		return dataSourceProperties.initializeDataSourceBuilder()
+			.type(HikariDataSource.class)
+			.build();
+	}
+
+	@Bean
+	@Primary
+	DataSource lazyConnectionDataSource(final HikariDataSource hikariDataSource) {
+		return new LazyConnectionDataSourceProxy(hikariDataSource);
+	}
+}

--- a/common/mathrank-lazy-connection/src/main/java/kr/co/mathrank/common/lazyconnection/LazyConnectionDataSourceProxyConfiguration.java
+++ b/common/mathrank-lazy-connection/src/main/java/kr/co/mathrank/common/lazyconnection/LazyConnectionDataSourceProxyConfiguration.java
@@ -1,7 +1,6 @@
 package kr.co.mathrank.common.lazyconnection;
 
 import javax.sql.DataSource;
-import javax.xml.crypto.Data;
 
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.context.annotation.Bean;

--- a/settings.gradle
+++ b/settings.gradle
@@ -69,6 +69,7 @@ include(
         'domain:mathrank-point-domain',
 
         'common',
+        'common:mathrank-lazy-connection',
         'common:mathrank-cache',
         'common:mathrank-cache-redis',
         'common:mathrank-cache-caffeine',


### PR DESCRIPTION
- 외부 API 요청과 DB 커넥션 점유 분리
- 전역 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure**
  * Added lazy connection initialization to optimize when database connections are created and reduce resource overhead.
  * Introduced a new shared configuration module for centralized data source management and connection pooling.

* **Dependencies**
  * Added Spring Data JPA support to the shared module and wired the monolith API to use the new module.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->