### PR TITLE
fix(oauth): Apple 로그인 시 userName이 null이 되는 문제 수정

### DIFF
--- a/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/AppleMemberInfoResponse.java
+++ b/domain/mathrank-auth-domain/src/main/java/kr/co/mathrank/domain/auth/client/AppleMemberInfoResponse.java
@@ -6,6 +6,13 @@ record AppleMemberInfoResponse(
 ) implements MemberInfoResponse {
 	@Override
 	public MemberInfo toInfo() {
-		return new MemberInfo(sub, null, email, null, null);
+		return new MemberInfo(sub, getNickName(), email, null, null);
+	}
+
+	private String getNickName() {
+		if (email != null && email.contains("@")) {
+			return email.substring(0, email.indexOf("@"));
+		}
+		return sub;
 	}
 }


### PR DESCRIPTION
fix(oauth): Apple 로그인 시 userName이 null이 되는 문제 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated Apple sign-in to improve user display name generation by utilizing email information when available, with enhanced fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->