### PR TITLE
feat: add assessment attempt and ranking flow

### DIFF
--- a/app/api/mathrank-problem-assessment-api/src/main/java/kr/co/mathrank/app/api/assessment/AssessmentController.java
+++ b/app/api/mathrank-problem-assessment-api/src/main/java/kr/co/mathrank/app/api/assessment/AssessmentController.java
@@ -20,12 +20,14 @@ import kr.co.mathrank.app.api.common.authentication.Authorization;
 import kr.co.mathrank.app.api.common.authentication.LoginInfo;
 import kr.co.mathrank.app.api.common.authentication.MemberPrincipal;
 import kr.co.mathrank.common.role.Role;
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentAttemptResult;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentDeleteCommand;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentRegisterCommand;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentSolutionQuery;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentSolutionQueryResult;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentUpdateCommand;
 import kr.co.mathrank.domain.problem.assessment.dto.SubmissionRegisterCommand;
+import kr.co.mathrank.domain.problem.assessment.service.AssessmentAttemptService;
 import kr.co.mathrank.domain.problem.assessment.service.AssessmentDeleteService;
 import kr.co.mathrank.domain.problem.assessment.service.AssessmentRegisterService;
 import kr.co.mathrank.domain.problem.assessment.service.AssessmentSolutionQueryService;
@@ -38,6 +40,7 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "문제집 API")
 public class AssessmentController {
 	private final AssessmentRegisterService assessmentRegisterService;
+	private final AssessmentAttemptService assessmentAttemptService;
 	private final SubmissionRegisterService submissionRegisterService;
 	private final AssessmentUpdateService assessmentUpdateService;
 	private final AssessmentDeleteService assessmentDeleteService;
@@ -46,14 +49,42 @@ public class AssessmentController {
 	@Operation(summary = "문제집 등록", description = "문제집 등록은 관리자만 가능합니다.")
 	@PostMapping("/api/v1/problem/assessment")
 	@Authorization(values = Role.ADMIN)
-	public ResponseEntity<Void> registerAssessment(
+	public ResponseEntity<Responses.AssessmentRegisterResponse> registerAssessment(
 		@RequestBody @Valid final Requests.AssessmentRegisterRequest request,
 		@LoginInfo final MemberPrincipal memberPrincipal
 	) {
 		final AssessmentRegisterCommand command = request.toCommand(memberPrincipal.memberId(), memberPrincipal.role());
-		assessmentRegisterService.register(command);
+		final Long assessmentId = assessmentRegisterService.register(command);
 
-		return ResponseEntity.status(HttpStatus.CREATED).build();
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(Responses.AssessmentRegisterResponse.from(assessmentId));
+	}
+
+	@Operation(summary = "문제집 응시 시작 API", description = "서버 시각을 기준으로 응시를 시작하거나 진행 중 응시를 반환합니다.")
+	@PostMapping("/api/v1/problem/assessment/{assessmentId}/attempts")
+	@Authorization(openedForAll = true)
+	public ResponseEntity<Responses.AssessmentAttemptResponse> startAttempt(
+		@PathVariable final Long assessmentId,
+		@LoginInfo final MemberPrincipal memberPrincipal
+	) {
+		final AssessmentAttemptResult result = assessmentAttemptService.start(
+			assessmentId, memberPrincipal.memberId());
+		final HttpStatus status = result.newlyCreated() ? HttpStatus.CREATED : HttpStatus.OK;
+		return ResponseEntity.status(status).body(Responses.AssessmentAttemptResponse.from(result));
+	}
+
+	@Operation(summary = "문제집 응시 답안 제출 API", description = "응시 시작 시각과 잠금·종료 시각을 서버에서 검증합니다.")
+	@PostMapping("/api/v1/problem/assessment/attempts/{attemptId}/submission")
+	@Authorization(openedForAll = true)
+	public ResponseEntity<Responses.AssessmentAttemptSubmissionResponse> submitAttempt(
+		@PathVariable final Long attemptId,
+		@RequestBody @Valid final Requests.AssessmentAttemptSubmissionRequest request,
+		@LoginInfo final MemberPrincipal memberPrincipal
+	) {
+		final Long submissionId = assessmentAttemptService.submit(
+			request.toCommand(memberPrincipal.memberId(), attemptId));
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(Responses.AssessmentAttemptSubmissionResponse.from(submissionId));
 	}
 
 	@Operation(summary = "문제집 답안지 등록 API")
@@ -87,7 +118,11 @@ public class AssessmentController {
 		@PathVariable final Long assessmentId,
 		@LoginInfo final MemberPrincipal memberPrincipal
 	) {
-		final AssessmentDeleteCommand command = new AssessmentDeleteCommand(assessmentId, memberPrincipal.memberId(), memberPrincipal.role());
+		final AssessmentDeleteCommand command = new AssessmentDeleteCommand(
+			assessmentId,
+			memberPrincipal.memberId(),
+			memberPrincipal.role()
+		);
 		assessmentDeleteService.delete(command);
 		return ResponseEntity.ok().build();
 	}
@@ -99,7 +134,11 @@ public class AssessmentController {
 		@PathVariable final Long assessmentId,
 		@LoginInfo final MemberPrincipal memberPrincipal
 	) {
-		final AssessmentSolutionQuery query = new AssessmentSolutionQuery(assessmentId, memberPrincipal.memberId(), memberPrincipal.role());
+		final AssessmentSolutionQuery query = new AssessmentSolutionQuery(
+			assessmentId,
+			memberPrincipal.memberId(),
+			memberPrincipal.role()
+		);
 		final AssessmentSolutionQueryResult result = assessmentSolutionQueryService.querySolutions(query);
 		return ResponseEntity.ok(result);
 	}

--- a/app/api/mathrank-problem-assessment-api/src/main/java/kr/co/mathrank/app/api/assessment/Requests.java
+++ b/app/api/mathrank-problem-assessment-api/src/main/java/kr/co/mathrank/app/api/assessment/Requests.java
@@ -10,13 +10,14 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import kr.co.mathrank.common.role.Role;
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentAttemptSubmissionCommand;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentItemRegisterCommand;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentRegisterCommand;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentUpdateCommand;
 import kr.co.mathrank.domain.problem.assessment.dto.SubmissionRegisterCommand;
 
 public class Requests {
-	record AssessmentRegisterRequest (
+	record AssessmentRegisterRequest(
 		@NotBlank
 		String assessmentName,
 
@@ -28,7 +29,10 @@ public class Requests {
 		@NotNull
 		@Min(1)
 		@Max(600)
-		Long minutes // 시험 시간
+		Long minutes, // 시험 시간
+
+		@Min(0)
+		Long answerInputDelaySeconds
 	) {
 		public AssessmentRegisterCommand toCommand(final Long registerMemberId, final Role role) {
 			return new AssessmentRegisterCommand(
@@ -38,7 +42,8 @@ public class Requests {
 				items.stream()
 					.map(AssessmentItemRegisterRequest::toCommand)
 					.toList(),
-				Duration.ofMinutes(minutes)
+				Duration.ofMinutes(minutes),
+				Duration.ofSeconds(answerInputDelaySeconds == null ? 0L : answerInputDelaySeconds)
 			);
 		}
 	}
@@ -65,6 +70,15 @@ public class Requests {
 		public SubmissionRegisterCommand toCommand(final Long memberId) {
 			return new SubmissionRegisterCommand(memberId, assessmentId, submittedAnswers,
 				Duration.ofSeconds(elapsedTimeSeconds));
+		}
+	}
+
+	record AssessmentAttemptSubmissionRequest(
+		@NotNull
+		List<List<String>> submittedAnswers
+	) {
+		public AssessmentAttemptSubmissionCommand toCommand(final Long memberId, final Long attemptId) {
+			return new AssessmentAttemptSubmissionCommand(memberId, attemptId, submittedAnswers);
 		}
 	}
 

--- a/app/api/mathrank-problem-assessment-api/src/main/java/kr/co/mathrank/app/api/assessment/Responses.java
+++ b/app/api/mathrank-problem-assessment-api/src/main/java/kr/co/mathrank/app/api/assessment/Responses.java
@@ -1,0 +1,43 @@
+package kr.co.mathrank.app.api.assessment;
+
+import java.time.Instant;
+
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentAttemptResult;
+
+class Responses {
+	record AssessmentRegisterResponse(String assessmentId) {
+		static AssessmentRegisterResponse from(final Long assessmentId) {
+			return new AssessmentRegisterResponse(String.valueOf(assessmentId));
+		}
+	}
+
+	record AssessmentAttemptResponse(
+		String attemptId,
+		Integer attemptNumber,
+		Instant startedAt,
+		Instant serverNow,
+		Instant answerUnlockedAt,
+		Instant expiresAt,
+		Boolean answerInputEnabled,
+		Boolean rankEligible
+	) {
+		static AssessmentAttemptResponse from(final AssessmentAttemptResult result) {
+			return new AssessmentAttemptResponse(
+				String.valueOf(result.attemptId()),
+				result.attemptNumber(),
+				result.startedAt(),
+				result.serverNow(),
+				result.answerUnlockedAt(),
+				result.expiresAt(),
+				result.answerInputEnabled(),
+				result.rankEligible()
+			);
+		}
+	}
+
+	record AssessmentAttemptSubmissionResponse(String submissionId) {
+		static AssessmentAttemptSubmissionResponse from(final Long submissionId) {
+			return new AssessmentAttemptSubmissionResponse(String.valueOf(submissionId));
+		}
+	}
+}

--- a/app/api/mathrank-problem-assessment-api/src/test/java/kr/co/mathrank/app/api/assessment/ResponsesTest.java
+++ b/app/api/mathrank-problem-assessment-api/src/test/java/kr/co/mathrank/app/api/assessment/ResponsesTest.java
@@ -1,0 +1,17 @@
+package kr.co.mathrank.app.api.assessment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ResponsesTest {
+	@Test
+	@DisplayName("시험지 등록 응답은 QR 생성에 사용할 assessmentId를 문자열로 반환한다")
+	void assessmentRegisterResponse() {
+		final Responses.AssessmentRegisterResponse response =
+			Responses.AssessmentRegisterResponse.from(123L);
+
+		assertThat(response.assessmentId()).isEqualTo("123");
+	}
+}

--- a/app/api/mathrank-problem-assessment-read-api/src/main/java/kr/co/mathrank/app/api/problem/assessment/AssessmentReadController.java
+++ b/app/api/mathrank-problem-assessment-read-api/src/main/java/kr/co/mathrank/app/api/problem/assessment/AssessmentReadController.java
@@ -19,6 +19,7 @@ import kr.co.mathrank.domain.problem.assessment.dto.AssessmentDetailQuery;
 import kr.co.mathrank.domain.problem.assessment.entity.AssessmentOrder;
 import kr.co.mathrank.domain.problem.assessment.entity.AssessmentOrderDirection;
 import kr.co.mathrank.domain.problem.assessment.service.AssessmentDetailReadService;
+import kr.co.mathrank.domain.problem.assessment.service.AssessmentAttemptService;
 import kr.co.mathrank.domain.problem.assessment.service.AssessmentQueryService;
 import kr.co.mathrank.domain.problem.assessment.service.AssessmentRankQueryService;
 import kr.co.mathrank.domain.problem.assessment.service.SubmissionQueryService;
@@ -29,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AssessmentReadController {
 	private final AssessmentQueryService assessmentQueryService;
+	private final AssessmentAttemptService assessmentAttemptService;
 	private final SubmissionQueryService submissionQueryService;
 	private final AssessmentDetailReadService assessmentDetailReadService;
 	private final AssessmentRankQueryService assessmentRankQueryService;
@@ -42,6 +44,19 @@ public class AssessmentReadController {
 		final Responses.AssessmentSubmissionQueryResponse response = Responses.AssessmentSubmissionQueryResponse.from(
 			submissionQueryService.getSubmissionResult(submissionId));
 		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "진행 중인 문제집 응시 조회 API")
+	@Authorization(openedForAll = true)
+	@GetMapping("/api/v1/problem/assessment/{assessmentId}/attempts/active")
+	public ResponseEntity<Responses.AssessmentAttemptResponse> getActiveAttempt(
+		@PathVariable final Long assessmentId,
+		@LoginInfo final MemberPrincipal memberPrincipal
+	) {
+		return assessmentAttemptService.getActive(assessmentId, memberPrincipal.memberId())
+			.map(Responses.AssessmentAttemptResponse::from)
+			.map(ResponseEntity::ok)
+			.orElseGet(() -> ResponseEntity.noContent().build());
 	}
 
 	@Operation(summary = "제출 이력 확인 API")

--- a/app/api/mathrank-problem-assessment-read-api/src/main/java/kr/co/mathrank/app/api/problem/assessment/Responses.java
+++ b/app/api/mathrank-problem-assessment-read-api/src/main/java/kr/co/mathrank/app/api/problem/assessment/Responses.java
@@ -1,10 +1,12 @@
 package kr.co.mathrank.app.api.problem.assessment;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentDetailReadModelResult;
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentAttemptResult;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentItemReadModelDetailResult;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentPageQueryResult;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentSubmissionRankResult;
@@ -18,6 +20,30 @@ import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
 
 class Responses {
+	public record AssessmentAttemptResponse(
+		String attemptId,
+		Integer attemptNumber,
+		Instant startedAt,
+		Instant serverNow,
+		Instant answerUnlockedAt,
+		Instant expiresAt,
+		Boolean answerInputEnabled,
+		Boolean rankEligible
+	) {
+		public static AssessmentAttemptResponse from(final AssessmentAttemptResult result) {
+			return new AssessmentAttemptResponse(
+				String.valueOf(result.attemptId()),
+				result.attemptNumber(),
+				result.startedAt(),
+				result.serverNow(),
+				result.answerUnlockedAt(),
+				result.expiresAt(),
+				result.answerInputEnabled(),
+				result.rankEligible()
+			);
+		}
+	}
+
 	public record AssessmentSubmissionRankResponse(
 		List<Integer> descendingScores,
 		Integer score,
@@ -25,7 +51,9 @@ class Responses {
 		List<Long> ascendingElapsedTimeSeconds,
 		Long elapsedTimeSeconds,
 		Integer elapsedTimeRank,
-		Integer totalUserCount
+		Integer totalUserCount,
+		Integer overallRank,
+		Boolean rankEligible
 	) {
 		public static AssessmentSubmissionRankResponse from(final AssessmentSubmissionRankResult result) {
 			return new AssessmentSubmissionRankResponse(
@@ -37,7 +65,9 @@ class Responses {
 					.toList(),
 				result.elapsedTime().toSeconds(),
 				result.elapsedTimeRank(),
-				result.totalUserCount()
+				result.totalUserCount(),
+				result.overallRank(),
+				result.rankEligible()
 			);
 		}
 	}
@@ -84,7 +114,8 @@ class Responses {
 		Long distinctUserCount,
 		LocalDateTime createdAt,
 		Difficulty difficulty,
-		Long minutes
+		Long minutes,
+		Long answerInputDelaySeconds
 	) {
 		public static AssessmentDetailResponse from(AssessmentDetailReadModelResult result) {
 			return new AssessmentDetailResponse(
@@ -97,7 +128,8 @@ class Responses {
 				result.distinctUserCount(),
 				result.createdAt(),
 				result.difficulty(),
-				result.minutes()
+				result.minutes(),
+				result.answerInputDelaySeconds()
 			);
 		}
 	}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/AssessmentTimeConfiguration.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/AssessmentTimeConfiguration.java
@@ -1,0 +1,14 @@
+package kr.co.mathrank.domain.problem.assessment;
+
+import java.time.Clock;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AssessmentTimeConfiguration {
+	@Bean
+	public Clock assessmentClock() {
+		return Clock.systemUTC();
+	}
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentAttemptResult.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentAttemptResult.java
@@ -1,0 +1,36 @@
+package kr.co.mathrank.domain.problem.assessment.dto;
+
+import java.time.Instant;
+
+import kr.co.mathrank.domain.problem.assessment.entity.AssessmentAttempt;
+
+public record AssessmentAttemptResult(
+	Long attemptId,
+	Integer attemptNumber,
+	Instant startedAt,
+	Instant serverNow,
+	Instant answerUnlockedAt,
+	Instant expiresAt,
+	Boolean answerInputEnabled,
+	Boolean rankEligible,
+	Boolean newlyCreated
+) {
+	public static AssessmentAttemptResult from(
+		final AssessmentAttempt attempt,
+		final Instant serverNow,
+		final boolean rankEligible,
+		final boolean newlyCreated
+	) {
+		return new AssessmentAttemptResult(
+			attempt.getId(),
+			attempt.getAttemptNumber(),
+			attempt.getStartedAt(),
+			serverNow,
+			attempt.getAnswerUnlockedAt(),
+			attempt.getExpiresAt(),
+			attempt.isAnswerInputEnabledAt(serverNow),
+			rankEligible,
+			newlyCreated
+		);
+	}
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentAttemptSubmissionCommand.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentAttemptSubmissionCommand.java
@@ -1,0 +1,17 @@
+package kr.co.mathrank.domain.problem.assessment.dto;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotNull;
+
+public record AssessmentAttemptSubmissionCommand(
+	@NotNull
+	Long memberId,
+
+	@NotNull
+	Long attemptId,
+
+	@NotNull
+	List<List<String>> submittedAnswers
+) {
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentDetailReadModelResult.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentDetailReadModelResult.java
@@ -15,6 +15,7 @@ public record AssessmentDetailReadModelResult(
 	LocalDateTime createdAt,
 	Difficulty difficulty,
 	Long minutes,
+	Long answerInputDelaySeconds,
 	AssessmentPeriodType periodType,
 	LocalDateTime startAt,
 	LocalDateTime endAt
@@ -29,6 +30,7 @@ public record AssessmentDetailReadModelResult(
 			detailResult.createdAt(),
 			detailResult.difficulty(),
 			detailResult.minutes(),
+			detailResult.answerInputDelaySeconds(),
 			detailResult.periodType(),
 			detailResult.startAt(),
 			detailResult.endAt()

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentDetailResult.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentDetailResult.java
@@ -16,6 +16,7 @@ public record AssessmentDetailResult(
 	LocalDateTime createdAt,
 	Difficulty difficulty,
 	Long minutes,
+	Long answerInputDelaySeconds,
 	AssessmentPeriodType periodType,
 	LocalDateTime startAt,
 	LocalDateTime endAt
@@ -32,6 +33,7 @@ public record AssessmentDetailResult(
 			assessment.getCreatedAt(),
 			assessment.getDifficulty(),
 			assessment.getAssessmentDuration().toMinutes(),
+			assessment.getAnswerInputDelaySeconds(),
 			assessment.getAssessmentSubmissionPeriod().getPeriodType(),
 			assessment.getAssessmentSubmissionPeriod().getStartAt(),
 			assessment.getAssessmentSubmissionPeriod().getEndAt()

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentRegisterCommand.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentRegisterCommand.java
@@ -29,6 +29,18 @@ public record AssessmentRegisterCommand(
 
 	@NotNull
 	@AssessmentDurationConstraint(minIncludeMinutes = 1, maxIncludeMinutes = 60 * 10)
-	Duration minutes // 시험 시간
+	Duration minutes, // 시험 시간
+
+	@NotNull
+	Duration answerInputDelay
 ) {
+	public AssessmentRegisterCommand(
+		final Long registerMemberId,
+		final Role role,
+		final String assessmentName,
+		final List<AssessmentItemRegisterCommand> assessmentItems,
+		final Duration minutes
+	) {
+		this(registerMemberId, role, assessmentName, assessmentItems, minutes, Duration.ZERO);
+	}
 }

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentSubmissionRankResult.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentSubmissionRankResult.java
@@ -10,6 +10,8 @@ public record AssessmentSubmissionRankResult(
 	List<Duration> ascendingElapsedTimes,
 	Duration elapsedTime,
 	Integer elapsedTimeRank,
-	Integer totalUserCount
+	Integer totalUserCount,
+	Integer overallRank,
+	Boolean rankEligible
 ) {
 }

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentSubmissionStanding.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentSubmissionStanding.java
@@ -1,0 +1,9 @@
+package kr.co.mathrank.domain.problem.assessment.dto;
+
+import java.time.Duration;
+
+public record AssessmentSubmissionStanding(
+	Integer totalScore,
+	Duration elapsedTime
+) {
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentSubmissionStatisticQueryResult.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentSubmissionStatisticQueryResult.java
@@ -6,6 +6,7 @@ import java.util.List;
 public record AssessmentSubmissionStatisticQueryResult(
 	Long assessmentId,
 	List<Integer> descendingScores,
-	List<Duration> ascendingElapsedTimes
+	List<Duration> ascendingElapsedTimes,
+	List<AssessmentSubmissionStanding> officialStandings
 ) {
 }

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/Assessment.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/Assessment.java
@@ -54,6 +54,8 @@ public class Assessment {
 	@Convert(converter = AssessmentDurationConverter.class)
 	private Duration assessmentDuration;
 
+	private Long answerInputDelaySeconds = 0L;
+
 	@Convert(converter = DifficultyConverter.class)
 	private Difficulty difficulty;
 
@@ -82,10 +84,16 @@ public class Assessment {
 	private AssessmentSubmissionPeriod assessmentSubmissionPeriod = new AssessmentSubmissionPeriod();
 
 	public static Assessment unlimited(final Long registerMemberId, final String assessmentName, final Duration assessmentDuration) {
+		return unlimited(registerMemberId, assessmentName, assessmentDuration, Duration.ZERO);
+	}
+
+	public static Assessment unlimited(final Long registerMemberId, final String assessmentName,
+		final Duration assessmentDuration, final Duration answerInputDelay) {
 		final Assessment assessment = new Assessment();
 		assessment.registerMemberId = registerMemberId;
 		assessment.assessmentName = assessmentName;
 		assessment.assessmentDuration = assessmentDuration;
+		assessment.answerInputDelaySeconds = answerInputDelay.getSeconds();
 		assessment.assessmentSubmissionPeriod = AssessmentSubmissionPeriod.unlimited();
 
 		return assessment;
@@ -99,6 +107,10 @@ public class Assessment {
 		assessment.assessmentSubmissionPeriod = AssessmentSubmissionPeriod.limited(startAt, endAt);
 
 		return assessment;
+	}
+
+	public Duration getAnswerInputDelay() {
+		return Duration.ofSeconds(answerInputDelaySeconds);
 	}
 
 	public void addNewSubmittedScore(int score) {

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentAttempt.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentAttempt.java
@@ -1,0 +1,122 @@
+package kr.co.mathrank.domain.problem.assessment.entity;
+
+import java.time.Instant;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(
+	name = "assessment_attempt",
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "uk_assessment_attempt_number",
+			columnNames = {"assessment_id", "member_id", "attempt_number"}
+		),
+		@UniqueConstraint(name = "uk_assessment_attempt_active_key", columnNames = "active_key")
+	},
+	indexes = {
+		@Index(name = "idx_assessment_attempt_assessment_member", columnList = "assessment_id, member_id"),
+		@Index(name = "idx_assessment_attempt_submission", columnList = "submission_id")
+	}
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AssessmentAttempt {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "assessment_id", nullable = false)
+	private Long assessmentId;
+
+	@Column(name = "member_id", nullable = false)
+	private Long memberId;
+
+	@Column(name = "attempt_number", nullable = false)
+	private Integer attemptNumber;
+
+	@Column(name = "started_at", nullable = false)
+	private Instant startedAt;
+
+	@Column(name = "answer_unlocked_at", nullable = false)
+	private Instant answerUnlockedAt;
+
+	@Column(name = "expires_at", nullable = false)
+	private Instant expiresAt;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private AssessmentAttemptStatus status;
+
+	@Column(name = "submission_id")
+	private Long submissionId;
+
+	@Column(name = "active_key")
+	private String activeKey;
+
+	@CreationTimestamp
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private Instant createdAt;
+
+	@UpdateTimestamp
+	@Column(name = "updated_at", nullable = false)
+	private Instant updatedAt;
+
+	public static AssessmentAttempt start(
+		final Long assessmentId,
+		final Long memberId,
+		final Integer attemptNumber,
+		final Instant startedAt,
+		final Instant answerUnlockedAt,
+		final Instant expiresAt
+	) {
+		final AssessmentAttempt attempt = new AssessmentAttempt();
+		attempt.assessmentId = assessmentId;
+		attempt.memberId = memberId;
+		attempt.attemptNumber = attemptNumber;
+		attempt.startedAt = startedAt;
+		attempt.answerUnlockedAt = answerUnlockedAt;
+		attempt.expiresAt = expiresAt;
+		attempt.status = AssessmentAttemptStatus.ACTIVE;
+		attempt.activeKey = activeKey(assessmentId, memberId);
+		return attempt;
+	}
+
+	public static String activeKey(final Long assessmentId, final Long memberId) {
+		return assessmentId + ":" + memberId;
+	}
+
+	public boolean isExpiredAt(final Instant now) {
+		return now.isAfter(expiresAt);
+	}
+
+	public boolean isAnswerInputEnabledAt(final Instant now) {
+		return !now.isBefore(answerUnlockedAt) && !isExpiredAt(now);
+	}
+
+	public void expire() {
+		status = AssessmentAttemptStatus.EXPIRED;
+		activeKey = null;
+	}
+
+	public void submit(final Long submissionId) {
+		this.submissionId = submissionId;
+		status = AssessmentAttemptStatus.SUBMITTED;
+		activeKey = null;
+	}
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentAttemptStatus.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentAttemptStatus.java
@@ -1,0 +1,7 @@
+package kr.co.mathrank.domain.problem.assessment.entity;
+
+public enum AssessmentAttemptStatus {
+	ACTIVE,
+	SUBMITTED,
+	EXPIRED
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/exception/AssessmentAttemptException.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/exception/AssessmentAttemptException.java
@@ -1,0 +1,37 @@
+package kr.co.mathrank.domain.problem.assessment.exception;
+
+import kr.co.mathrank.common.exception.HttpMathRankException;
+
+public class AssessmentAttemptException extends HttpMathRankException {
+	private AssessmentAttemptException(final int httpStatusCode, final int code, final String message) {
+		super(httpStatusCode, code, message);
+	}
+
+	public static AssessmentAttemptException notFound() {
+		return new AssessmentAttemptException(404, 7013, "응시 기록을 찾을 수 없습니다.");
+	}
+
+	public static AssessmentAttemptException accessDenied() {
+		return new AssessmentAttemptException(403, 7014, "다른 사용자의 응시 기록에는 접근할 수 없습니다.");
+	}
+
+	public static AssessmentAttemptException answerLocked() {
+		return new AssessmentAttemptException(409, 7015, "아직 답안을 입력할 수 없습니다.");
+	}
+
+	public static AssessmentAttemptException expired() {
+		return new AssessmentAttemptException(409, 7016, "시험 시간이 만료되었습니다.");
+	}
+
+	public static AssessmentAttemptException alreadySubmitted() {
+		return new AssessmentAttemptException(409, 7017, "이미 제출된 응시 기록입니다.");
+	}
+
+	public static AssessmentAttemptException attemptRequired() {
+		return new AssessmentAttemptException(409, 7018, "시험 시작 후 응시 기록을 통해 제출해야 합니다.");
+	}
+
+	public static AssessmentAttemptException invalidAnswer() {
+		return new AssessmentAttemptException(400, 7019, "제출 답안 형식이 올바르지 않습니다.");
+	}
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/exception/InvalidAssessmentAnswerInputDelayException.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/exception/InvalidAssessmentAnswerInputDelayException.java
@@ -1,0 +1,9 @@
+package kr.co.mathrank.domain.problem.assessment.exception;
+
+import kr.co.mathrank.common.exception.HttpMathRankException;
+
+public class InvalidAssessmentAnswerInputDelayException extends HttpMathRankException {
+	public InvalidAssessmentAnswerInputDelayException() {
+		super(400, 7020, "답안 입력 잠금 시간은 0 이상이며 시험 시간보다 짧아야 합니다.");
+	}
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/repository/AssessmentAttemptRepository.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/repository/AssessmentAttemptRepository.java
@@ -1,0 +1,28 @@
+package kr.co.mathrank.domain.problem.assessment.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import jakarta.persistence.LockModeType;
+import kr.co.mathrank.domain.problem.assessment.entity.AssessmentAttempt;
+
+public interface AssessmentAttemptRepository extends JpaRepository<AssessmentAttempt, Long> {
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT attempt FROM AssessmentAttempt attempt WHERE attempt.activeKey = :activeKey")
+	Optional<AssessmentAttempt> findByActiveKeyForUpdate(@Param("activeKey") String activeKey);
+
+	Optional<AssessmentAttempt> findByActiveKey(String activeKey);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT attempt FROM AssessmentAttempt attempt WHERE attempt.id = :attemptId")
+	Optional<AssessmentAttempt> findByIdForUpdate(@Param("attemptId") Long attemptId);
+
+	Optional<AssessmentAttempt> findTopByAssessmentIdAndMemberIdOrderByAttemptNumberDesc(
+		Long assessmentId,
+		Long memberId
+	);
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/repository/AssessmentSubmissionRepository.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/repository/AssessmentSubmissionRepository.java
@@ -13,6 +13,8 @@ import kr.co.mathrank.domain.problem.assessment.entity.Assessment;
 import kr.co.mathrank.domain.problem.assessment.entity.AssessmentSubmission;
 
 public interface AssessmentSubmissionRepository extends JpaRepository<AssessmentSubmission, Long> {
+	boolean existsByAssessmentIdAndMemberId(Long assessmentId, Long memberId);
+
 	@Query("""
 		SELECT s FROM AssessmentSubmission s
 		LEFT JOIN FETCH s.assessment

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentAttemptService.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentAttemptService.java
@@ -1,0 +1,142 @@
+package kr.co.mathrank.domain.problem.assessment.service;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.client.internal.problem.ProblemQueryResult;
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentAttemptResult;
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentAttemptSubmissionCommand;
+import kr.co.mathrank.domain.problem.assessment.dto.SubmissionRegisterCommand;
+import kr.co.mathrank.domain.problem.assessment.entity.Assessment;
+import kr.co.mathrank.domain.problem.assessment.entity.AssessmentAttempt;
+import kr.co.mathrank.domain.problem.assessment.entity.AssessmentAttemptStatus;
+import kr.co.mathrank.domain.problem.assessment.entity.AssessmentItem;
+import kr.co.mathrank.domain.problem.assessment.exception.AssessmentAttemptException;
+import kr.co.mathrank.domain.problem.assessment.exception.NoSuchAssessmentException;
+import kr.co.mathrank.domain.problem.assessment.repository.AssessmentAttemptRepository;
+import kr.co.mathrank.domain.problem.assessment.repository.AssessmentRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Validated
+@RequiredArgsConstructor
+public class AssessmentAttemptService {
+	private static final int MAX_SHORT_ANSWERS = 100;
+
+	private final AssessmentAttemptStartManager assessmentAttemptStartManager;
+	private final AssessmentAttemptRepository assessmentAttemptRepository;
+	private final AssessmentRepository assessmentRepository;
+	private final SubmissionRegisterService submissionRegisterService;
+	private final ProblemQueryManager problemQueryManager;
+	private final Clock assessmentClock;
+
+	public AssessmentAttemptResult start(@NotNull final Long assessmentId, @NotNull final Long memberId) {
+		try {
+			return assessmentAttemptStartManager.start(assessmentId, memberId);
+		} catch (DataIntegrityViolationException exception) {
+			return assessmentAttemptStartManager.getActive(assessmentId, memberId)
+				.orElseThrow(() -> exception);
+		}
+	}
+
+	public Optional<AssessmentAttemptResult> getActive(
+		@NotNull final Long assessmentId,
+		@NotNull final Long memberId
+	) {
+		return assessmentAttemptStartManager.getActive(assessmentId, memberId);
+	}
+
+	@Transactional
+	public Long submit(@NotNull @Valid final AssessmentAttemptSubmissionCommand command) {
+		final AssessmentAttempt attempt = assessmentAttemptRepository.findByIdForUpdate(command.attemptId())
+			.orElseThrow(AssessmentAttemptException::notFound);
+		if (!attempt.getMemberId().equals(command.memberId())) {
+			throw AssessmentAttemptException.accessDenied();
+		}
+		if (attempt.getStatus() == AssessmentAttemptStatus.SUBMITTED) {
+			throw AssessmentAttemptException.alreadySubmitted();
+		}
+		if (attempt.getStatus() == AssessmentAttemptStatus.EXPIRED) {
+			throw AssessmentAttemptException.expired();
+		}
+
+		final Instant now = assessmentClock.instant();
+		if (attempt.isExpiredAt(now)) {
+			attempt.expire();
+			throw AssessmentAttemptException.expired();
+		}
+		if (!attempt.isAnswerInputEnabledAt(now)) {
+			throw AssessmentAttemptException.answerLocked();
+		}
+
+		final Assessment assessment = assessmentRepository.findWithItems(attempt.getAssessmentId())
+			.orElseThrow(NoSuchAssessmentException::new);
+		final List<List<String>> normalizedAnswers = normalizeAnswers(assessment, command.submittedAnswers());
+		final Duration elapsedTime = Duration.between(attempt.getStartedAt(), now);
+		final Long submissionId = submissionRegisterService.submitFromAttempt(new SubmissionRegisterCommand(
+			command.memberId(),
+			attempt.getAssessmentId(),
+			normalizedAnswers,
+			elapsedTime
+		));
+		attempt.submit(submissionId);
+		return submissionId;
+	}
+
+	private List<List<String>> normalizeAnswers(
+		final Assessment assessment,
+		final List<List<String>> submittedAnswers
+	) {
+		if (assessment.getAssessmentItems().size() != submittedAnswers.size()) {
+			throw AssessmentAttemptException.invalidAnswer();
+		}
+
+		final List<List<String>> normalizedAnswers = new ArrayList<>(submittedAnswers.size());
+		for (int index = 0; index < submittedAnswers.size(); index++) {
+			final AssessmentItem item = assessment.getAssessmentItems().get(index);
+			final ProblemQueryResult problem = problemQueryManager.getProblemInfo(item.getProblemId());
+			if (submittedAnswers.get(index) == null
+				|| submittedAnswers.get(index).stream().anyMatch(answer -> answer == null)) {
+				throw AssessmentAttemptException.invalidAnswer();
+			}
+			final List<String> normalized = submittedAnswers.get(index).stream()
+				.map(String::trim)
+				.filter(answer -> !answer.isEmpty())
+				.toList();
+			if (new HashSet<>(normalized).size() != normalized.size()) {
+				throw AssessmentAttemptException.invalidAnswer();
+			}
+			switch (problem.type()) {
+				case MULTIPLE_CHOICE -> validateMultipleChoice(normalized);
+				case SHORT_ANSWER -> {
+					if (normalized.size() > MAX_SHORT_ANSWERS) {
+						throw AssessmentAttemptException.invalidAnswer();
+					}
+				}
+			}
+			normalizedAnswers.add(normalized);
+		}
+		return normalizedAnswers;
+	}
+
+	private void validateMultipleChoice(final List<String> answers) {
+		if (answers.size() > 5) {
+			throw AssessmentAttemptException.invalidAnswer();
+		}
+		if (answers.stream().anyMatch(answer -> !answer.matches("[1-5]"))) {
+			throw AssessmentAttemptException.invalidAnswer();
+		}
+	}
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentAttemptStartManager.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentAttemptStartManager.java
@@ -1,0 +1,84 @@
+package kr.co.mathrank.domain.problem.assessment.service;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentAttemptResult;
+import kr.co.mathrank.domain.problem.assessment.entity.Assessment;
+import kr.co.mathrank.domain.problem.assessment.entity.AssessmentAttempt;
+import kr.co.mathrank.domain.problem.assessment.exception.NoSuchAssessmentException;
+import kr.co.mathrank.domain.problem.assessment.repository.AssessmentAttemptRepository;
+import kr.co.mathrank.domain.problem.assessment.repository.AssessmentRepository;
+import kr.co.mathrank.domain.problem.assessment.repository.AssessmentSubmissionRepository;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+class AssessmentAttemptStartManager {
+	private final AssessmentRepository assessmentRepository;
+	private final AssessmentAttemptRepository assessmentAttemptRepository;
+	private final AssessmentSubmissionRepository assessmentSubmissionRepository;
+	private final Clock assessmentClock;
+
+	@Transactional
+	public AssessmentAttemptResult start(final Long assessmentId, final Long memberId) {
+		final Assessment assessment = assessmentRepository.findById(assessmentId)
+			.orElseThrow(NoSuchAssessmentException::new);
+		final Instant now = assessmentClock.instant();
+		final String activeKey = AssessmentAttempt.activeKey(assessmentId, memberId);
+
+		final Optional<AssessmentAttempt> activeAttempt =
+			assessmentAttemptRepository.findByActiveKeyForUpdate(activeKey);
+		if (activeAttempt.isPresent() && !activeAttempt.get().isExpiredAt(now)) {
+			return result(activeAttempt.get(), now, false);
+		}
+		if (activeAttempt.isPresent()) {
+			activeAttempt.get().expire();
+			assessmentAttemptRepository.flush();
+		}
+
+		final int attemptNumber = assessmentAttemptRepository
+			.findTopByAssessmentIdAndMemberIdOrderByAttemptNumberDesc(assessmentId, memberId)
+			.map(previous -> previous.getAttemptNumber() + 1)
+			.orElse(1);
+		final AssessmentAttempt attempt = AssessmentAttempt.start(
+			assessmentId,
+			memberId,
+			attemptNumber,
+			now,
+			now.plus(assessment.getAnswerInputDelay()),
+			now.plus(assessment.getAssessmentDuration())
+		);
+		assessmentAttemptRepository.saveAndFlush(attempt);
+		return result(attempt, now, true);
+	}
+
+	@Transactional
+	public Optional<AssessmentAttemptResult> getActive(final Long assessmentId, final Long memberId) {
+		final Instant now = assessmentClock.instant();
+		final Optional<AssessmentAttempt> activeAttempt = assessmentAttemptRepository.findByActiveKeyForUpdate(
+			AssessmentAttempt.activeKey(assessmentId, memberId));
+		if (activeAttempt.isEmpty()) {
+			return Optional.empty();
+		}
+		if (activeAttempt.get().isExpiredAt(now)) {
+			activeAttempt.get().expire();
+			return Optional.empty();
+		}
+		return Optional.of(result(activeAttempt.get(), now, false));
+	}
+
+	private AssessmentAttemptResult result(
+		final AssessmentAttempt attempt,
+		final Instant now,
+		final boolean newlyCreated
+	) {
+		final boolean rankEligible = !assessmentSubmissionRepository.existsByAssessmentIdAndMemberId(
+			attempt.getAssessmentId(), attempt.getMemberId());
+		return AssessmentAttemptResult.from(attempt, now, rankEligible, newlyCreated);
+	}
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentRankQueryService.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentRankQueryService.java
@@ -10,6 +10,7 @@ import org.springframework.validation.annotation.Validated;
 import kr.co.mathrank.domain.problem.assessment.AssessmentReadDomainConfiguration;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentSubmissionRankResult;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentSubmissionStatisticQueryResult;
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentSubmissionStanding;
 import kr.co.mathrank.domain.problem.assessment.entity.AssessmentSubmission;
 import kr.co.mathrank.domain.problem.assessment.entity.EvaluationStatus;
 import kr.co.mathrank.domain.problem.assessment.exception.NoSuchSubmissionException;
@@ -58,7 +59,9 @@ public class AssessmentRankQueryService {
 				result.ascendingElapsedTimes(),
 				assessmentSubmission.getElapsedTime(),
 				elapsedTimeRank == null ? result.descendingScores().size() : elapsedTimeRank,
-				result.ascendingElapsedTimes().size()
+				result.officialStandings().size(),
+				getOverallRank(result.officialStandings(), assessmentSubmission),
+				true
 			);
 		}
 
@@ -74,8 +77,24 @@ public class AssessmentRankQueryService {
 			result.ascendingElapsedTimes(),
 			assessmentSubmission.getElapsedTime(),
 			elapsedTimeRank == null ? result.descendingScores().size() + 1 : elapsedTimeRank,
-			result.descendingScores().size() + 1
+			result.officialStandings().size(),
+			null,
+			false
 		);
+	}
+
+	private Integer getOverallRank(
+		final List<AssessmentSubmissionStanding> standings,
+		final AssessmentSubmission submission
+	) {
+		for (int index = 0; index < standings.size(); index++) {
+			final AssessmentSubmissionStanding standing = standings.get(index);
+			if (standing.totalScore().equals(submission.getTotalScore())
+				&& standing.elapsedTime().equals(submission.getElapsedTime())) {
+				return index + 1;
+			}
+		}
+		return null;
 	}
 
 	private Integer getElapsedTimeRank(final List<Duration> ascendingDurations, final Duration elapsedTime) {

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentRegisterService.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentRegisterService.java
@@ -19,6 +19,7 @@ import kr.co.mathrank.domain.problem.assessment.entity.Assessment;
 import kr.co.mathrank.domain.problem.assessment.entity.AssessmentItem;
 import kr.co.mathrank.domain.problem.assessment.entity.AssessmentPeriodType;
 import kr.co.mathrank.domain.problem.assessment.exception.AssessmentRegisterException;
+import kr.co.mathrank.domain.problem.assessment.exception.InvalidAssessmentAnswerInputDelayException;
 import kr.co.mathrank.domain.problem.assessment.repository.AssessmentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,7 +34,12 @@ public class AssessmentRegisterService {
 
 	@Transactional
 	public Long register(@NotNull @Valid final AssessmentRegisterCommand command) {
-		final Assessment assessment = Assessment.unlimited(command.registerMemberId(), command.assessmentName(), command.minutes());
+		if (command.answerInputDelay().isNegative()
+			|| command.answerInputDelay().compareTo(command.minutes()) >= 0) {
+			throw new InvalidAssessmentAnswerInputDelayException();
+		}
+		final Assessment assessment = Assessment.unlimited(command.registerMemberId(), command.assessmentName(),
+			command.minutes(), command.answerInputDelay());
 
 		return register(assessment, command.role(), toItems(command.assessmentItems())).getId();
 	}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentStatisticsService.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentStatisticsService.java
@@ -11,6 +11,7 @@ import org.springframework.validation.annotation.Validated;
 import jakarta.validation.constraints.NotNull;
 import kr.co.mathrank.domain.problem.assessment.AssessmentReadDomainConfiguration;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentSubmissionStatisticQueryResult;
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentSubmissionStanding;
 import kr.co.mathrank.domain.problem.assessment.entity.Assessment;
 import kr.co.mathrank.domain.problem.assessment.entity.AssessmentSubmission;
 import kr.co.mathrank.domain.problem.assessment.entity.EvaluationStatus;
@@ -41,11 +42,18 @@ public class AssessmentStatisticsService {
 
 		final List<Duration> ascendingDurations = ascendingSortElapsedTimes(submissions);
 		final List<Integer> descendingScores = descendingSortScores(submissions);
+		final List<AssessmentSubmissionStanding> officialStandings = submissions.stream()
+			.sorted(Comparator.comparing(AssessmentSubmission::getTotalScore).reversed()
+				.thenComparing(AssessmentSubmission::getElapsedTime))
+			.map(submission -> new AssessmentSubmissionStanding(
+				submission.getTotalScore(), submission.getElapsedTime()))
+			.toList();
 
 		return new AssessmentSubmissionStatisticQueryResult(
 			assessmentId,
 			descendingScores,
-			ascendingDurations
+			ascendingDurations,
+			officialStandings
 		);
 	}
 

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/SubmissionRegisterService.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/SubmissionRegisterService.java
@@ -14,6 +14,7 @@ import kr.co.mathrank.domain.problem.assessment.dto.SubmissionRegisterCommand;
 import kr.co.mathrank.domain.problem.assessment.entity.Assessment;
 import kr.co.mathrank.domain.problem.assessment.entity.AssessmentSubmission;
 import kr.co.mathrank.domain.problem.assessment.exception.NoSuchAssessmentException;
+import kr.co.mathrank.domain.problem.assessment.exception.AssessmentAttemptException;
 import kr.co.mathrank.domain.problem.assessment.repository.AssessmentRepository;
 import kr.co.mathrank.domain.problem.assessment.repository.AssessmentSubmissionRepository;
 import lombok.RequiredArgsConstructor;
@@ -57,6 +58,15 @@ public class SubmissionRegisterService {
 	 */
 	@Transactional
 	public Long submit(@NotNull @Valid final SubmissionRegisterCommand command) {
+		return submit(command, false);
+	}
+
+	@Transactional
+	public Long submitFromAttempt(@NotNull @Valid final SubmissionRegisterCommand command) {
+		return submit(command, true);
+	}
+
+	private Long submit(final SubmissionRegisterCommand command, final boolean attemptValidated) {
 		// X-Lock
 		final Assessment assessment = assessmentRepository.findWithItemsForUpdate(command.assessmentId())
 			.orElseThrow(() -> {
@@ -64,6 +74,10 @@ public class SubmissionRegisterService {
 					command.assessmentId());
 				return new NoSuchAssessmentException();
 			});
+
+		if (!attemptValidated && assessment.getAnswerInputDelaySeconds() > 0L) {
+			throw AssessmentAttemptException.attemptRequired();
+		}
 
 		// 처음으로 제출한 사용자일때
 		final boolean isFirstSubmission = isFirstTry(command.assessmentId(), command.memberId());

--- a/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentAttemptTest.java
+++ b/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentAttemptTest.java
@@ -1,0 +1,54 @@
+package kr.co.mathrank.domain.problem.assessment.entity;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+class AssessmentAttemptTest {
+	private static final Instant STARTED_AT = Instant.parse("2026-07-23T00:00:00Z");
+
+	@Test
+	void 답안_잠금과_시험_종료_경계를_서버시각으로_판정한다() {
+		final AssessmentAttempt attempt = AssessmentAttempt.start(
+			1L,
+			2L,
+			1,
+			STARTED_AT,
+			STARTED_AT.plusSeconds(900),
+			STARTED_AT.plusSeconds(3600)
+		);
+
+		assertFalse(attempt.isAnswerInputEnabledAt(STARTED_AT.plusSeconds(899)));
+		assertTrue(attempt.isAnswerInputEnabledAt(STARTED_AT.plusSeconds(900)));
+		assertFalse(attempt.isExpiredAt(STARTED_AT.plusSeconds(3600)));
+		assertTrue(attempt.isExpiredAt(STARTED_AT.plusSeconds(3601)));
+	}
+
+	@Test
+	void 제출하거나_만료되면_activeKey를_비운다() {
+		final AssessmentAttempt submitted = newAttempt();
+		submitted.submit(10L);
+		assertNull(submitted.getActiveKey());
+		assertTrue(submitted.getStatus() == AssessmentAttemptStatus.SUBMITTED);
+
+		final AssessmentAttempt expired = newAttempt();
+		expired.expire();
+		assertNull(expired.getActiveKey());
+		assertTrue(expired.getStatus() == AssessmentAttemptStatus.EXPIRED);
+	}
+
+	private AssessmentAttempt newAttempt() {
+		return AssessmentAttempt.start(
+			1L,
+			2L,
+			1,
+			STARTED_AT,
+			STARTED_AT.plusSeconds(900),
+			STARTED_AT.plusSeconds(3600)
+		);
+	}
+}

--- a/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentAttemptServiceTest.java
+++ b/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentAttemptServiceTest.java
@@ -1,0 +1,172 @@
+package kr.co.mathrank.domain.problem.assessment.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import kr.co.mathrank.client.internal.problem.ProblemQueryResult;
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentAttemptSubmissionCommand;
+import kr.co.mathrank.domain.problem.assessment.dto.SubmissionRegisterCommand;
+import kr.co.mathrank.domain.problem.assessment.entity.Assessment;
+import kr.co.mathrank.domain.problem.assessment.entity.AssessmentAttempt;
+import kr.co.mathrank.domain.problem.assessment.entity.AssessmentAttemptStatus;
+import kr.co.mathrank.domain.problem.assessment.entity.AssessmentItem;
+import kr.co.mathrank.domain.problem.assessment.exception.AssessmentAttemptException;
+import kr.co.mathrank.domain.problem.assessment.repository.AssessmentAttemptRepository;
+import kr.co.mathrank.domain.problem.assessment.repository.AssessmentRepository;
+import kr.co.mathrank.domain.problem.core.AnswerType;
+import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.core.PastProblem;
+
+class AssessmentAttemptServiceTest {
+	private static final Instant STARTED_AT = Instant.parse("2026-07-23T00:00:00Z");
+
+	@Test
+	void 시작_후_15분_전에는_제출할_수_없다() {
+		final Fixture fixture = fixture(STARTED_AT.plusSeconds(899));
+
+		assertThrows(AssessmentAttemptException.class, () -> fixture.service.submit(
+			new AssessmentAttemptSubmissionCommand(2L, 1L, List.of(List.of("1")))
+		));
+	}
+
+	@Test
+	void 시작_후_15분부터_서버가_계산한_시간으로_제출한다() {
+		final Fixture fixture = fixture(STARTED_AT.plusSeconds(900));
+
+		assertEquals(99L, fixture.service.submit(
+			new AssessmentAttemptSubmissionCommand(2L, 1L, List.of(List.of("1")))
+		));
+		assertEquals(AssessmentAttemptStatus.SUBMITTED, fixture.attempt.getStatus());
+		assertEquals(99L, fixture.attempt.getSubmissionId());
+	}
+
+	@Test
+	void 객관식은_1부터_5까지_다중선택을_허용한다() {
+		final Fixture fixture = fixture(STARTED_AT.plusSeconds(900));
+
+		fixture.service.submit(
+			new AssessmentAttemptSubmissionCommand(2L, 1L, List.of(List.of("1", "3", "5")))
+		);
+
+		final ArgumentCaptor<SubmissionRegisterCommand> captor =
+			ArgumentCaptor.forClass(SubmissionRegisterCommand.class);
+		verify(fixture.submissionRegisterService).submitFromAttempt(captor.capture());
+		assertEquals(List.of(List.of("1", "3", "5")), captor.getValue().submittedAnswers());
+	}
+
+	@Test
+	void 객관식은_1부터_5_밖의_선택지를_거부한다() {
+		final Fixture fixture = fixture(STARTED_AT.plusSeconds(900));
+
+		assertThrows(AssessmentAttemptException.class, () -> fixture.service.submit(
+			new AssessmentAttemptSubmissionCommand(2L, 1L, List.of(List.of("1", "6")))
+		));
+	}
+
+	@Test
+	void 제한시간을_넘긴_제출은_거부한다() {
+		final Fixture fixture = fixture(STARTED_AT.plusSeconds(3601));
+
+		assertThrows(AssessmentAttemptException.class, () -> fixture.service.submit(
+			new AssessmentAttemptSubmissionCommand(2L, 1L, List.of(List.of("1")))
+		));
+	}
+
+	@Test
+	void 주관식_복수답안은_trim하고_순서를_유지해_채점에_전달한다() {
+		final Fixture fixture = fixture(STARTED_AT.plusSeconds(900), AnswerType.SHORT_ANSWER);
+
+		fixture.service.submit(
+			new AssessmentAttemptSubmissionCommand(2L, 1L, List.of(List.of(" 42 ", "7")))
+		);
+
+		final ArgumentCaptor<SubmissionRegisterCommand> captor =
+			ArgumentCaptor.forClass(SubmissionRegisterCommand.class);
+		verify(fixture.submissionRegisterService).submitFromAttempt(captor.capture());
+		assertEquals(List.of(List.of("42", "7")), captor.getValue().submittedAnswers());
+	}
+
+	@Test
+	void 주관식_중복답안은_거부한다() {
+		final Fixture fixture = fixture(STARTED_AT.plusSeconds(900), AnswerType.SHORT_ANSWER);
+
+		assertThrows(AssessmentAttemptException.class, () -> fixture.service.submit(
+			new AssessmentAttemptSubmissionCommand(2L, 1L, List.of(List.of("42", " 42 ")))
+		));
+	}
+
+	private Fixture fixture(final Instant now) {
+		return fixture(now, AnswerType.MULTIPLE_CHOICE);
+	}
+
+	private Fixture fixture(final Instant now, final AnswerType answerType) {
+		final AssessmentAttemptStartManager startManager = mock(AssessmentAttemptStartManager.class);
+		final AssessmentAttemptRepository attemptRepository = mock(AssessmentAttemptRepository.class);
+		final AssessmentRepository assessmentRepository = mock(AssessmentRepository.class);
+		final SubmissionRegisterService submissionRegisterService = mock(SubmissionRegisterService.class);
+		final ProblemQueryManager problemQueryManager = mock(ProblemQueryManager.class);
+		final Clock clock = Clock.fixed(now, ZoneOffset.UTC);
+		final AssessmentAttempt attempt = AssessmentAttempt.start(
+			1L, 2L, 1, STARTED_AT, STARTED_AT.plusSeconds(900), STARTED_AT.plusSeconds(3600));
+		final Assessment assessment = Assessment.unlimited(
+			1L, "test", Duration.ofMinutes(60), Duration.ofMinutes(15));
+		assessment.replaceItems(List.of(AssessmentItem.of(10L, 100)));
+		final ProblemQueryResult problem = new ProblemQueryResult(
+			10L,
+			1L,
+			"problem.png",
+			"path",
+			Difficulty.MID,
+			answerType,
+			PastProblem.NONE,
+			null,
+			Set.of("1"),
+			null,
+			null,
+			null,
+			null,
+			null,
+			null
+		);
+
+		when(attemptRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(attempt));
+		when(assessmentRepository.findWithItems(1L)).thenReturn(Optional.of(assessment));
+		when(problemQueryManager.getProblemInfo(10L)).thenReturn(problem);
+		when(submissionRegisterService.submitFromAttempt(any())).thenReturn(99L);
+
+		return new Fixture(
+			new AssessmentAttemptService(
+				startManager,
+				attemptRepository,
+				assessmentRepository,
+				submissionRegisterService,
+				problemQueryManager,
+				clock
+			),
+			attempt,
+			submissionRegisterService
+		);
+	}
+
+	private record Fixture(
+		AssessmentAttemptService service,
+		AssessmentAttempt attempt,
+		SubmissionRegisterService submissionRegisterService
+	) {
+	}
+}

--- a/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentRankQueryServiceTest.java
+++ b/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentRankQueryServiceTest.java
@@ -1,0 +1,110 @@
+package kr.co.mathrank.domain.problem.assessment.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentSubmissionRankResult;
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentSubmissionStanding;
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentSubmissionStatisticQueryResult;
+import kr.co.mathrank.domain.problem.assessment.entity.Assessment;
+import kr.co.mathrank.domain.problem.assessment.entity.AssessmentItem;
+import kr.co.mathrank.domain.problem.assessment.entity.AssessmentSubmission;
+import kr.co.mathrank.domain.problem.assessment.entity.GradeResult;
+import kr.co.mathrank.domain.problem.assessment.repository.AssessmentSubmissionRepository;
+
+@ExtendWith(MockitoExtension.class)
+class AssessmentRankQueryServiceTest {
+	@Mock
+	private AssessmentSubmissionRepository assessmentSubmissionRepository;
+	@Mock
+	private AssessmentStatisticsService assessmentStatisticsService;
+
+	private AssessmentRankQueryService service;
+
+	@BeforeEach
+	void setUp() {
+		service = new AssessmentRankQueryService(assessmentSubmissionRepository, assessmentStatisticsService);
+	}
+
+	@Test
+	void 점수_우선_동점이면_풀이시간으로_공식등수를_계산한다() {
+		final AssessmentSubmission submission = finishedSubmission(true, Duration.ofMinutes(7));
+		final List<AssessmentSubmissionStanding> standings = List.of(
+			new AssessmentSubmissionStanding(100, Duration.ofMinutes(5)),
+			new AssessmentSubmissionStanding(100, Duration.ofMinutes(7)),
+			new AssessmentSubmissionStanding(90, Duration.ofMinutes(1))
+		);
+		mockResult(submission, standings);
+
+		final AssessmentSubmissionRankResult result = service.getRank(1L);
+
+		assertEquals(2, result.overallRank());
+		assertEquals(3, result.totalUserCount());
+		assertTrue(result.rankEligible());
+	}
+
+	@Test
+	void 점수와_시간이_같으면_공동등수다() {
+		final AssessmentSubmission submission = finishedSubmission(true, Duration.ofMinutes(5));
+		final List<AssessmentSubmissionStanding> standings = List.of(
+			new AssessmentSubmissionStanding(100, Duration.ofMinutes(5)),
+			new AssessmentSubmissionStanding(100, Duration.ofMinutes(5)),
+			new AssessmentSubmissionStanding(90, Duration.ofMinutes(1))
+		);
+		mockResult(submission, standings);
+
+		assertEquals(1, service.getRank(1L).overallRank());
+	}
+
+	@Test
+	void 재응시는_공식등수에_포함하지_않는다() {
+		final AssessmentSubmission submission = finishedSubmission(false, Duration.ofMinutes(3));
+		mockResult(submission, List.of(
+			new AssessmentSubmissionStanding(100, Duration.ofMinutes(5))
+		));
+
+		final AssessmentSubmissionRankResult result = service.getRank(1L);
+
+		assertFalse(result.rankEligible());
+		assertNull(result.overallRank());
+		assertEquals(1, result.totalUserCount());
+	}
+
+	private AssessmentSubmission finishedSubmission(final boolean first, final Duration elapsedTime) {
+		final Assessment assessment = Assessment.unlimited(1L, "test", Duration.ofMinutes(60));
+		assessment.replaceItems(List.of(AssessmentItem.of(10L, 100)));
+		final AssessmentSubmission submission = assessment.registerSubmission(
+			2L, List.of(List.of("1")), elapsedTime, first);
+		submission.grade(List.of(new GradeResult(10L, Collections.singletonList("1"), true)));
+		return submission;
+	}
+
+	private void mockResult(
+		final AssessmentSubmission submission,
+		final List<AssessmentSubmissionStanding> standings
+	) {
+		when(assessmentSubmissionRepository.findById(1L)).thenReturn(Optional.of(submission));
+		when(assessmentStatisticsService.query(submission.getAssessment().getId())).thenReturn(
+			new AssessmentSubmissionStatisticQueryResult(
+				submission.getAssessment().getId(),
+				standings.stream().map(AssessmentSubmissionStanding::totalScore).toList(),
+				standings.stream().map(AssessmentSubmissionStanding::elapsedTime).sorted().toList(),
+				standings
+			)
+		);
+	}
+}

--- a/scripts/db/V20260723_01__assessment_attempt.sql
+++ b/scripts/db/V20260723_01__assessment_attempt.sql
@@ -1,0 +1,24 @@
+ALTER TABLE assessment
+	ADD COLUMN answer_input_delay_seconds BIGINT NOT NULL DEFAULT 0;
+
+CREATE TABLE assessment_attempt (
+	id BIGINT NOT NULL AUTO_INCREMENT,
+	assessment_id BIGINT NOT NULL,
+	member_id BIGINT NOT NULL,
+	attempt_number INT NOT NULL,
+	started_at DATETIME(6) NOT NULL,
+	answer_unlocked_at DATETIME(6) NOT NULL,
+	expires_at DATETIME(6) NOT NULL,
+	status VARCHAR(32) NOT NULL,
+	submission_id BIGINT NULL,
+	active_key VARCHAR(255) NULL,
+	created_at DATETIME(6) NOT NULL,
+	updated_at DATETIME(6) NOT NULL,
+	PRIMARY KEY (id),
+	CONSTRAINT uk_assessment_attempt_number
+		UNIQUE (assessment_id, member_id, attempt_number),
+	CONSTRAINT uk_assessment_attempt_active_key
+		UNIQUE (active_key),
+	INDEX idx_assessment_attempt_assessment_member (assessment_id, member_id),
+	INDEX idx_assessment_attempt_submission (submission_id)
+);

--- a/scripts/db/V20260723_01__assessment_attempt_RUNBOOK.md
+++ b/scripts/db/V20260723_01__assessment_attempt_RUNBOOK.md
@@ -1,0 +1,60 @@
+# Assessment attempt 운영 DB 반영
+
+이 저장소는 운영 Flyway/Liquibase 정본을 사용하지 않으므로 애플리케이션 배포 전에
+`V20260723_01__assessment_attempt.sql`을 운영 MySQL에 한 번만 수동 적용한다.
+`spring.jpa.hibernate.ddl-auto=update`는 사용하지 않는다.
+
+## 사전 확인
+
+```sql
+SELECT VERSION();
+
+SELECT COUNT(*) AS assessment_table_count
+FROM information_schema.tables
+WHERE table_schema = DATABASE()
+  AND table_name = 'assessment';
+
+SELECT COUNT(*) AS delay_column_count
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND table_name = 'assessment'
+  AND column_name = 'answer_input_delay_seconds';
+
+SELECT COUNT(*) AS attempt_table_count
+FROM information_schema.tables
+WHERE table_schema = DATABASE()
+  AND table_name = 'assessment_attempt';
+```
+
+`assessment_table_count=1`, `delay_column_count=0`, `attempt_table_count=0`일 때만 migration을 실행한다.
+
+## 적용 순서
+
+1. 운영 DB 백업 또는 복구 지점을 확인한다.
+2. `V20260723_01__assessment_attempt.sql`을 실행한다.
+3. 아래 사후 검증을 실행한다.
+4. 검증 성공 후 신규 애플리케이션을 배포한다.
+
+## 사후 검증
+
+```sql
+SELECT column_name, column_type, is_nullable, column_default
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND table_name = 'assessment'
+  AND column_name = 'answer_input_delay_seconds';
+
+SHOW CREATE TABLE assessment_attempt;
+
+SELECT COUNT(*) AS non_zero_existing_delay_count
+FROM assessment
+WHERE answer_input_delay_seconds <> 0;
+```
+
+기존 assessment의 delay는 모두 `0`이어야 한다.
+
+## 롤백
+
+신규 애플리케이션 배포에 실패하면 이전 애플리케이션 버전으로 되돌린다. 추가된 컬럼과
+테이블은 이전 버전이 참조하지 않으므로 즉시 삭제하지 않는다. 데이터 삭제가 필요한
+down migration은 별도 점검과 백업 후 수행한다.


### PR DESCRIPTION
## What changed

- Added server-managed assessment attempts with start, active-attempt resume, and attempt-based submission APIs.
- Enforced the 15-minute answer-input lock and calculated elapsed time from server timestamps.
- Added first-submission-only official ranking ordered by score descending and elapsed time ascending, including shared ranks for exact ties.
- Added reattempt support with `rankEligible=false` for non-first submissions.
- Added fixed 1–5 multi-select validation for multiple-choice answers and direct-input normalization for short answers.
- Extended assessment registration responses with `assessmentId` for the admin PDF/QR workflow.
- Added the additive production DB migration and runbook.

## Why

Printed MathRank assessments need a QR-driven mobile flow where students start an attempt, wait 15 minutes before entering answers, submit for server grading, and see their official rank for that assessment.

## Database

The additive migration was applied to the production `mathrank` database after creating the snapshot `database-2-pre-assessment-attempt-20260729`. Postflight checks confirmed the new column, table, constraints, and indexes. Existing assessments retain a zero-second delay and the attempt table was empty after migration.

## Verification

- Focused assessment attempt and ranking tests
- Assessment API response test
- Assessment API Checkstyle
- Monolith `bootJar`
- `git diff --check`
- Live Swagger recheck: production is still `v1.0.0-beta.21` with 53 paths / 73 operations and does not yet expose the new attempt APIs

## Deployment note

Merging this PR does not deploy production by itself. The repository deployment workflow runs on a new `v*` tag, so create the next release tag only after review and merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added assessment attempts with start, resume, expiration, and submission support.
  * Added active-attempt retrieval and clear attempt status information.
  * Added configurable answer-input delays with validation.
  * Added official rankings based on score and elapsed time.
  * Assessment registration now returns the created assessment ID.

* **Bug Fixes**
  * Added validation for submitted answers, timing, ownership, duplicates, and invalid attempts.

* **Documentation**
  * Added a runbook for applying and validating the assessment database update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->